### PR TITLE
Explain the Event listener list and give it a default implementation

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -222,21 +222,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     private void addToListeners(final Object target, final Class<?> eventType, final IEventListener listener, final EventPriority priority) {
-        ListenerList listenerList;
-        if (Modifier.isAbstract(eventType.getModifiers())) {
-            // fall back on the slower static map of event listener lists for abstract classes
-            listenerList = Event.getListenerList(eventType);
-        } else {
-            try {
-                Constructor<?> ctr = eventType.getConstructor();
-                ctr.setAccessible(true);
-                Event event = (Event) ctr.newInstance();
-                listenerList = event.getListenerList();
-            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-                LOGGER.error(EVENTBUS, "Error registering event handler: {} {}", eventType.getName(), target, e);
-                throw new RuntimeException("Error registering event handler on " + eventType.getName(), e);
-            }
-        }
+        ListenerList listenerList = Event.getListenerList(eventType);
         listenerList.register(busID, priority, listener);
         List<IEventListener> others = listeners.computeIfAbsent(target, k -> new ArrayList<>());
         others.add(listener);

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -222,23 +222,24 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     private void addToListeners(final Object target, final Class<?> eventType, final IEventListener listener, final EventPriority priority) {
-        try {
-            if (Modifier.isAbstract(eventType.getModifiers())) {
-                // Currently throw an exception: see issue #5
-                LOGGER.fatal(EVENTBUS,"Unable to register listener on abstract class {}", eventType.getName());
-                throw new RuntimeException("Unable to register an event listener on abstract event class "+ eventType.getName());
+        ListenerList listenerList;
+        if (Modifier.isAbstract(eventType.getModifiers())) {
+            // fall back on the slower static map of event listener lists for abstract classes
+            listenerList = Event.getListenerList(eventType);
+        } else {
+            try {
+                Constructor<?> ctr = eventType.getConstructor();
+                ctr.setAccessible(true);
+                Event event = (Event) ctr.newInstance();
+                listenerList = event.getListenerList();
+            } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                LOGGER.error(EVENTBUS, "Error registering event handler: {} {}", eventType.getName(), target, e);
+                throw new RuntimeException("Error registering event handler on " + eventType.getName(), e);
             }
-            Constructor<?> ctr = eventType.getConstructor();
-            ctr.setAccessible(true);
-            Event event = (Event)ctr.newInstance();
-            event.getListenerList().register(busID, priority, listener);
-
-            ArrayList<IEventListener> others = listeners.computeIfAbsent(target, k -> new ArrayList<>());
-            others.add(listener);
-        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
-            LOGGER.error(EVENTBUS, "Error registering event handler: {} {}", eventType.getName(), target, e);
-            throw new RuntimeException("Error registering event handler on "+eventType.getName(), e);
         }
+        listenerList.register(busID, priority, listener);
+        List<IEventListener> others = listeners.computeIfAbsent(target, k -> new ArrayList<>());
+        others.add(listener);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -222,7 +222,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     private void addToListeners(final Object target, final Class<?> eventType, final IEventListener listener, final EventPriority priority) {
-        ListenerList listenerList = Event.getListenerList(eventType);
+        ListenerList listenerList = EventListenerHelper.getListenerList(eventType);
         listenerList.register(busID, priority, listener);
         List<IEventListener> others = listeners.computeIfAbsent(target, k -> new ArrayList<>());
         others.add(listener);

--- a/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
@@ -188,7 +188,7 @@ public class EventSubclassTransformer
         method.instructions.add(new TypeInsnNode(NEW, tList.getInternalName()));
         method.instructions.add(new InsnNode(DUP));
         method.instructions.add(new VarInsnNode(ALOAD, 0));
-        method.instructions.add(new MethodInsnNode(INVOKESPECIAL, tThis.getInternalName(), "getParentListenerList", listDescM, false));
+        method.instructions.add(new MethodInsnNode(INVOKEVIRTUAL, tThis.getInternalName(), "getParentListenerList", listDescM, false));
         method.instructions.add(new MethodInsnNode(INVOKESPECIAL, tList.getInternalName(), "<init>", getMethodDescriptor(VOID_TYPE, tList), false));
         method.instructions.add(new FieldInsnNode(PUTSTATIC, classNode.name, "LISTENER_LIST", listDesc));
         method.instructions.add(new InsnNode(RETURN));

--- a/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
@@ -144,6 +144,7 @@ public class EventSubclassTransformer
             }
         }
 
+        Type tThis = Type.getObjectType(classNode.name);
         Type tSuper = Type.getObjectType(classNode.superName);
 
         //Add private static ListenerList LISTENER_LIST
@@ -172,7 +173,7 @@ public class EventSubclassTransformer
          *              {
          *                      return;
          *              }
-         *              LISTENER_LIST = new ListenerList(super.getListenerList());
+         *              LISTENER_LIST = new ListenerList(this.getParentListenerList());
          *      }
          */
         MethodNode method = new MethodNode(ACC_PROTECTED, "setup", voidDesc, null, null);
@@ -187,7 +188,7 @@ public class EventSubclassTransformer
         method.instructions.add(new TypeInsnNode(NEW, tList.getInternalName()));
         method.instructions.add(new InsnNode(DUP));
         method.instructions.add(new VarInsnNode(ALOAD, 0));
-        method.instructions.add(new MethodInsnNode(INVOKESPECIAL, tSuper.getInternalName(), "getListenerList", listDescM, false));
+        method.instructions.add(new MethodInsnNode(INVOKESPECIAL, tThis.getInternalName(), "getParentListenerList", listDescM, false));
         method.instructions.add(new MethodInsnNode(INVOKESPECIAL, tList.getInternalName(), "<init>", getMethodDescriptor(VOID_TYPE, tList), false));
         method.instructions.add(new FieldInsnNode(PUTSTATIC, classNode.name, "LISTENER_LIST", listDesc));
         method.instructions.add(new InsnNode(RETURN));

--- a/src/main/java/net/minecraftforge/eventbus/api/Event.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/Event.java
@@ -170,7 +170,7 @@ public class Event
      *
      * @return Listener List
      */
-    public static ListenerList getListenerList(Class<?> eventClass)
+    static ListenerList getListenerList(Class<?> eventClass)
     {
         return getListenerListInternal(eventClass, false);
     }

--- a/src/main/java/net/minecraftforge/eventbus/api/Event.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/Event.java
@@ -157,7 +157,7 @@ public class Event
         return getListenerList(this.getClass());
     }
 
-    private static ListenerList getListenerList(Class<?> eventClass)
+    public static ListenerList getListenerList(Class<?> eventClass)
     {
         return listeners.computeIfAbsent(eventClass, (c) -> {
             if (eventClass == Event.class)

--- a/src/main/java/net/minecraftforge/eventbus/api/Event.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/Event.java
@@ -26,11 +26,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-import java.util.IdentityHashMap;
-import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.annotation.ElementType.TYPE;
@@ -54,7 +49,6 @@ public class Event
 
     private boolean isCanceled = false;
     private Result result = Result.DEFAULT;
-    private static Map<Class<?>, ListenerList> listeners = new IdentityHashMap<>();
     private EventPriority phase = null;
 
     public Event()
@@ -156,60 +150,12 @@ public class Event
      */
     public ListenerList getListenerList()
     {
-        return getListenerListInternal(this.getClass(), true);
+        return EventListenerHelper.getListenerListInternal(this.getClass(), true);
     }
 
-    /**
-     * Returns a ListenerList object that contains all listeners
-     * that are registered to this event class.
-     *
-     * This supports abstract classes that cannot be instantiated.
-     *
-     * Note: this is much slower than the instance method {@link #getListenerList()}.
-     * For performance when emitting events, always call that method instead.
-     *
-     * @return Listener List
-     */
-    static ListenerList getListenerList(Class<?> eventClass)
+    protected ListenerList getParentListenerList()
     {
-        return getListenerListInternal(eventClass, false);
-    }
-
-    protected final ListenerList getParentListenerList()
-    {
-        return getListenerListInternal(this.getClass().getSuperclass(), false);
-    }
-
-    private static ListenerList getListenerListInternal(Class<?> eventClass, boolean fromInstanceCall)
-    {
-        return listeners.computeIfAbsent(eventClass, c -> computeListenerList(eventClass, fromInstanceCall));
-    }
-
-    private static ListenerList computeListenerList(Class<?> eventClass, boolean fromInstanceCall)
-    {
-        if (eventClass == Event.class)
-        {
-            return new ListenerList();
-        }
-
-        if (fromInstanceCall || Modifier.isAbstract(eventClass.getModifiers()))
-        {
-            Class<?> superclass = eventClass.getSuperclass();
-            ListenerList parentList = getListenerList(superclass);
-            return new ListenerList(parentList);
-        }
-
-        try
-        {
-            Constructor<?> ctr = eventClass.getConstructor();
-            ctr.setAccessible(true);
-            Event event = (Event) ctr.newInstance();
-            return event.getListenerList();
-        }
-        catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e)
-        {
-            throw new RuntimeException("Error computing listener list for " + eventClass.getName(), e);
-        }
+        return EventListenerHelper.getListenerListInternal(this.getClass().getSuperclass(), false);
     }
 
     @Nullable

--- a/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
@@ -1,3 +1,22 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package net.minecraftforge.eventbus.api;
 
 import net.minecraftforge.eventbus.ListenerList;
@@ -10,51 +29,51 @@ import java.util.Map;
 
 public class EventListenerHelper
 {
-	private static Map<Class<?>, ListenerList> listeners = new IdentityHashMap<>();
+    private static Map<Class<?>, ListenerList> listeners = new IdentityHashMap<>();
 
-	/**
-	 * Returns a {@link ListenerList} object that contains all listeners
-	 * that are registered to this event class.
-	 *
-	 * This supports abstract classes that cannot be instantiated.
-	 *
-	 * Note: this is much slower than the instance method {@link Event#getListenerList()}.
-	 * For performance when emitting events, always call that method instead.
-	 */
-	public static ListenerList getListenerList(Class<?> eventClass)
-	{
-		return getListenerListInternal(eventClass, false);
-	}
+    /**
+     * Returns a {@link ListenerList} object that contains all listeners
+     * that are registered to this event class.
+     *
+     * This supports abstract classes that cannot be instantiated.
+     *
+     * Note: this is much slower than the instance method {@link Event#getListenerList()}.
+     * For performance when emitting events, always call that method instead.
+     */
+    public static ListenerList getListenerList(Class<?> eventClass)
+    {
+        return getListenerListInternal(eventClass, false);
+    }
 
-	static ListenerList getListenerListInternal(Class<?> eventClass, boolean fromInstanceCall)
-	{
-		return listeners.computeIfAbsent(eventClass, c -> computeListenerList(eventClass, fromInstanceCall));
-	}
+    static ListenerList getListenerListInternal(Class<?> eventClass, boolean fromInstanceCall)
+    {
+        return listeners.computeIfAbsent(eventClass, c -> computeListenerList(eventClass, fromInstanceCall));
+    }
 
-	private static ListenerList computeListenerList(Class<?> eventClass, boolean fromInstanceCall)
-	{
-		if (eventClass == Event.class)
-		{
-			return new ListenerList();
-		}
+    private static ListenerList computeListenerList(Class<?> eventClass, boolean fromInstanceCall)
+    {
+        if (eventClass == Event.class)
+        {
+            return new ListenerList();
+        }
 
-		if (fromInstanceCall || Modifier.isAbstract(eventClass.getModifiers()))
-		{
-			Class<?> superclass = eventClass.getSuperclass();
-			ListenerList parentList = getListenerList(superclass);
-			return new ListenerList(parentList);
-		}
+        if (fromInstanceCall || Modifier.isAbstract(eventClass.getModifiers()))
+        {
+            Class<?> superclass = eventClass.getSuperclass();
+            ListenerList parentList = getListenerList(superclass);
+            return new ListenerList(parentList);
+        }
 
-		try
-		{
-			Constructor<?> ctr = eventClass.getConstructor();
-			ctr.setAccessible(true);
-			Event event = (Event) ctr.newInstance();
-			return event.getListenerList();
-		}
-		catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e)
-		{
-			throw new RuntimeException("Error computing listener list for " + eventClass.getName(), e);
-		}
-	}
+        try
+        {
+            Constructor<?> ctr = eventClass.getConstructor();
+            ctr.setAccessible(true);
+            Event event = (Event) ctr.newInstance();
+            return event.getListenerList();
+        }
+        catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e)
+        {
+            throw new RuntimeException("Error computing listener list for " + eventClass.getName(), e);
+        }
+    }
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
@@ -1,0 +1,60 @@
+package net.minecraftforge.eventbus.api;
+
+import net.minecraftforge.eventbus.ListenerList;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+public class EventListenerHelper
+{
+	private static Map<Class<?>, ListenerList> listeners = new IdentityHashMap<>();
+
+	/**
+	 * Returns a {@link ListenerList} object that contains all listeners
+	 * that are registered to this event class.
+	 *
+	 * This supports abstract classes that cannot be instantiated.
+	 *
+	 * Note: this is much slower than the instance method {@link Event#getListenerList()}.
+	 * For performance when emitting events, always call that method instead.
+	 */
+	public static ListenerList getListenerList(Class<?> eventClass)
+	{
+		return getListenerListInternal(eventClass, false);
+	}
+
+	static ListenerList getListenerListInternal(Class<?> eventClass, boolean fromInstanceCall)
+	{
+		return listeners.computeIfAbsent(eventClass, c -> computeListenerList(eventClass, fromInstanceCall));
+	}
+
+	private static ListenerList computeListenerList(Class<?> eventClass, boolean fromInstanceCall)
+	{
+		if (eventClass == Event.class)
+		{
+			return new ListenerList();
+		}
+
+		if (fromInstanceCall || Modifier.isAbstract(eventClass.getModifiers()))
+		{
+			Class<?> superclass = eventClass.getSuperclass();
+			ListenerList parentList = getListenerList(superclass);
+			return new ListenerList(parentList);
+		}
+
+		try
+		{
+			Constructor<?> ctr = eventClass.getConstructor();
+			ctr.setAccessible(true);
+			Event event = (Event) ctr.newInstance();
+			return event.getListenerList();
+		}
+		catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e)
+		{
+			throw new RuntimeException("Error computing listener list for " + eventClass.getName(), e);
+		}
+	}
+}

--- a/src/main/java/net/minecraftforge/eventbus/api/GenericEvent.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/GenericEvent.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Type;
 public class GenericEvent<T> extends Event implements IGenericEvent<T>
 {
     private Class<T> type;
+    public GenericEvent() {}
     protected GenericEvent(Class<T> type)
     {
         this.type = type;

--- a/src/main/java/net/minecraftforge/eventbus/api/GenericEvent.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/GenericEvent.java
@@ -20,8 +20,6 @@ package net.minecraftforge.eventbus.api;
 
 import java.lang.reflect.Type;
 
-import net.minecraftforge.eventbus.ListenerList;
-
 /**
  * Implements {@link IGenericEvent} to provide filterable events based on generic type data.
  *
@@ -41,24 +39,5 @@ public class GenericEvent<T> extends Event implements IGenericEvent<T>
     public Type getGenericType()
     {
         return type;
-    }
-
-    //Default things that are added by EventSubclassTransformer, but as we are excluded from transformers we must add ourselves.
-    private static ListenerList LISTENER_LIST;
-    public GenericEvent(){ }
-
-    @Override
-    protected void setup()
-    {
-        super.setup();
-        if (LISTENER_LIST != null)
-            return;
-        LISTENER_LIST = new ListenerList(super.getListenerList());
-    }
-
-    @Override
-    public ListenerList getListenerList()
-    {
-        return LISTENER_LIST;
     }
 }

--- a/src/test/java/net/minecraftforge/eventbus/test/AbstractEventListenerTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/AbstractEventListenerTest.java
@@ -50,7 +50,7 @@ public class AbstractEventListenerTest {
 			super.setup();
 			if (LISTENER_LIST != null)
 				return;
-			LISTENER_LIST = new ListenerList(super.getListenerList());
+			LISTENER_LIST = new ListenerList(this.getParentListenerList());
 		}
 
 		@Override
@@ -74,7 +74,7 @@ public class AbstractEventListenerTest {
 			super.setup();
 			if (LISTENER_LIST != null)
 				return;
-			LISTENER_LIST = new ListenerList(super.getListenerList());
+			LISTENER_LIST = new ListenerList(this.getParentListenerList());
 		}
 
 		@Override

--- a/src/test/java/net/minecraftforge/eventbus/test/AbstractEventListenerTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/AbstractEventListenerTest.java
@@ -1,5 +1,6 @@
 package net.minecraftforge.eventbus.test;
 
+import net.minecraftforge.eventbus.ListenerList;
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -15,25 +16,72 @@ public class AbstractEventListenerTest {
 	void eventHandlersCanSubscribeToAbstractEvents() {
 		IEventBus bus = BusBuilder.builder().build();
 		AtomicBoolean abstractSuperEventHandled = new AtomicBoolean(false);
-		AtomicBoolean subEventHandled = new AtomicBoolean(false);
-		bus.addListener(EventPriority.NORMAL, false, AbstractSuperEvent.class, (event) -> {
-			abstractSuperEventHandled.set(true);
-		});
-		bus.addListener(EventPriority.NORMAL, false, ConcreteSubEvent.class, (event) -> {
-			subEventHandled.set(true);
-		});
+		AtomicBoolean concreteSuperEventHandled = new AtomicBoolean(false);
+		AtomicBoolean abstractSubEventHandled = new AtomicBoolean(false);
+		AtomicBoolean concreteSubEventHandled = new AtomicBoolean(false);
+		bus.addListener(EventPriority.NORMAL, false, AbstractSuperEvent.class, (event) -> abstractSuperEventHandled.set(true));
+		bus.addListener(EventPriority.NORMAL, false, ConcreteSuperEvent.class, (event) -> concreteSuperEventHandled.set(true));
+		bus.addListener(EventPriority.NORMAL, false, AbstractSubEvent.class, (event) -> abstractSubEventHandled.set(true));
+		bus.addListener(EventPriority.NORMAL, false, ConcreteSubEvent.class, (event) -> concreteSubEventHandled.set(true));
 
 		bus.post(new ConcreteSubEvent());
 
 		assertTrue(abstractSuperEventHandled.get(), "handled abstract super event");
-		assertTrue(subEventHandled.get(), "handled concrete sub event");
+		assertTrue(concreteSuperEventHandled.get(), "handled concrete super event");
+		assertTrue(abstractSubEventHandled.get(), "handled abstract sub event");
+		assertTrue(concreteSubEventHandled.get(), "handled concrete sub event");
 	}
+
+	// Below, we simulate the things that are added by EventSubclassTransformer
+	// to show that it will work alongside the static listener map.
 
 	public static abstract class AbstractSuperEvent extends Event {
 
 	}
 
-	public static class ConcreteSubEvent extends AbstractSuperEvent {
+	public static class ConcreteSuperEvent extends AbstractSuperEvent {
+
+		private static ListenerList LISTENER_LIST;
+		public ConcreteSuperEvent() {}
+
+		@Override
+		protected void setup()
+		{
+			super.setup();
+			if (LISTENER_LIST != null)
+				return;
+			LISTENER_LIST = new ListenerList(super.getListenerList());
+		}
+
+		@Override
+		public ListenerList getListenerList()
+		{
+			return LISTENER_LIST;
+		}
+	}
+
+	public static class AbstractSubEvent extends ConcreteSuperEvent {
 
 	}
+
+	public static class ConcreteSubEvent extends AbstractSubEvent {
+		private static ListenerList LISTENER_LIST;
+		public ConcreteSubEvent() {}
+
+		@Override
+		protected void setup()
+		{
+			super.setup();
+			if (LISTENER_LIST != null)
+				return;
+			LISTENER_LIST = new ListenerList(super.getListenerList());
+		}
+
+		@Override
+		public ListenerList getListenerList()
+		{
+			return LISTENER_LIST;
+		}
+	}
+
 }

--- a/src/test/java/net/minecraftforge/eventbus/test/AbstractEventListenerTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/AbstractEventListenerTest.java
@@ -1,0 +1,39 @@
+package net.minecraftforge.eventbus.test;
+
+import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.IEventBus;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AbstractEventListenerTest {
+	@Test
+	void eventHandlersCanSubscribeToAbstractEvents() {
+		IEventBus bus = BusBuilder.builder().build();
+		AtomicBoolean abstractSuperEventHandled = new AtomicBoolean(false);
+		AtomicBoolean subEventHandled = new AtomicBoolean(false);
+		bus.addListener(EventPriority.NORMAL, false, AbstractSuperEvent.class, (event) -> {
+			abstractSuperEventHandled.set(true);
+		});
+		bus.addListener(EventPriority.NORMAL, false, ConcreteSubEvent.class, (event) -> {
+			subEventHandled.set(true);
+		});
+
+		bus.post(new ConcreteSubEvent());
+
+		assertTrue(abstractSuperEventHandled.get(), "handled abstract super event");
+		assertTrue(subEventHandled.get(), "handled concrete sub event");
+	}
+
+	public static abstract class AbstractSuperEvent extends Event {
+
+	}
+
+	public static class ConcreteSubEvent extends AbstractSuperEvent {
+
+	}
+}

--- a/src/test/java/net/minecraftforge/eventbus/test/EventFiringEventTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/EventFiringEventTest.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.eventbus.test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.IEventBus;
+
+import org.junit.jupiter.api.Test;
+
+public class EventFiringEventTest {
+
+	@Test
+	void eventHandlersCanFireEvents() {
+		IEventBus bus = IEventBus.create();
+		AtomicBoolean handled1 = new AtomicBoolean(false);
+		AtomicBoolean handled2 = new AtomicBoolean(false);
+		bus.addListener(EventPriority.NORMAL, false, Event1.class, (event1) -> {
+			bus.post(new AbstractEvent.Event2());
+			handled1.set(true);
+		});
+		bus.addListener(EventPriority.NORMAL, false, AbstractEvent.Event2.class, (event2) -> {
+			handled2.set(true);
+		});
+
+		bus.post(new Event1());
+
+		assertTrue(handled1.get(), "handled Event1");
+		assertTrue(handled2.get(), "handled Event2");
+	}
+
+	public static class Event1 extends Event {
+
+	}
+
+	public static abstract class AbstractEvent extends Event {
+		public static class Event2 extends AbstractEvent {
+
+		}
+	}
+}

--- a/src/test/java/net/minecraftforge/eventbus/test/EventFiringEventTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/EventFiringEventTest.java
@@ -3,6 +3,8 @@ package net.minecraftforge.eventbus.test;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -13,7 +15,7 @@ public class EventFiringEventTest {
 
 	@Test
 	void eventHandlersCanFireEvents() {
-		IEventBus bus = IEventBus.create();
+		IEventBus bus = BusBuilder.builder().build();
 		AtomicBoolean handled1 = new AtomicBoolean(false);
 		AtomicBoolean handled2 = new AtomicBoolean(false);
 		bus.addListener(EventPriority.NORMAL, false, Event1.class, (event1) -> {

--- a/src/test/java/net/minecraftforge/eventbus/test/EventLambdaTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/EventLambdaTest.java
@@ -1,6 +1,5 @@
 package net.minecraftforge.eventbus.test;
 
-import net.minecraftforge.eventbus.ListenerList;
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -58,40 +57,12 @@ public class EventLambdaTest {
             }
         });
     }
-    // faked asm processing for easy testing
+
     public static class SubEvent extends Event {
-        private static ListenerList LISTENER_LIST;
-        protected void setup()
-        {
-            super.setup();
-            if (LISTENER_LIST != null)
-            {
-                return;
-            }
-            LISTENER_LIST = new ListenerList(super.getListenerList());
-        }
-        @Override
-        public ListenerList getListenerList() {
-            return LISTENER_LIST;
-        }
+
     }
 
     public static class CancellableEvent extends Event {
-        private static ListenerList LISTENER_LIST;
-        protected void setup()
-        {
-            super.setup();
-            if (LISTENER_LIST != null)
-            {
-                return;
-            }
-            LISTENER_LIST = new ListenerList(super.getListenerList());
-        }
-        @Override
-        public ListenerList getListenerList() {
-            return LISTENER_LIST;
-        }
-
         @Override
         public boolean isCancelable() {
             return true;

--- a/src/test/java/net/minecraftforge/eventbus/test/SubscribeToSuperEventTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/SubscribeToSuperEventTest.java
@@ -1,0 +1,42 @@
+package net.minecraftforge.eventbus.test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.IEventBus;
+
+import org.junit.jupiter.api.Test;
+
+public class SubscribeToSuperEventTest {
+
+	@Test
+	void eventHandlersCanSubscribeToSuperEvents() {
+		IEventBus bus = IEventBus.create();
+		AtomicBoolean superEventHandled = new AtomicBoolean(false);
+		AtomicBoolean subEventHandled = new AtomicBoolean(false);
+		bus.addListener(EventPriority.NORMAL, false, SuperEvent.class, (event) -> {
+			Class<? extends SuperEvent> eventClass = event.getClass();
+			if (eventClass == SuperEvent.class) {
+				superEventHandled.set(true);
+			} else if (eventClass == SubEvent.class) {
+				subEventHandled.set(true);
+			}
+		});
+
+		bus.post(new SuperEvent());
+		bus.post(new SubEvent());
+
+		assertTrue(superEventHandled.get(), "handled super event");
+		assertTrue(subEventHandled.get(), "handled sub event");
+	}
+
+	public static class SuperEvent extends Event {
+
+	}
+
+	public static class SubEvent extends SuperEvent {
+
+	}
+}

--- a/src/test/java/net/minecraftforge/eventbus/test/SubscribeToSuperEventTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/SubscribeToSuperEventTest.java
@@ -3,6 +3,8 @@ package net.minecraftforge.eventbus.test;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -13,7 +15,7 @@ public class SubscribeToSuperEventTest {
 
 	@Test
 	void eventHandlersCanSubscribeToSuperEvents() {
-		IEventBus bus = IEventBus.create();
+		IEventBus bus = BusBuilder.builder().build();
 		AtomicBoolean superEventHandled = new AtomicBoolean(false);
 		AtomicBoolean subEventHandled = new AtomicBoolean(false);
 		bus.addListener(EventPriority.NORMAL, false, SuperEvent.class, (event) -> {

--- a/src/test/java/net/minecraftforge/eventbus/test/WeirdGenericTests.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/WeirdGenericTests.java
@@ -7,7 +7,6 @@ import net.minecraftforge.eventbus.api.BusBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import net.minecraftforge.eventbus.EventBus;
 import net.minecraftforge.eventbus.api.GenericEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 
@@ -17,14 +16,14 @@ public class WeirdGenericTests {
 	
 	@Test
 	public void testGenericListener() {
-//		IEventBus bus = BusBuilder.builder().build();
-//		bus.addGenericListener(List.class, this::handleGenericEvent);
-//		bus.post(new GenericEvent<List<String>>() {
-//			public Type getGenericType() {
-//				return List.class;
-//			};
-//		});
-//		Assertions.assertTrue(genericEventHandled);
+		IEventBus bus = BusBuilder.builder().build();
+		bus.addGenericListener(List.class, this::handleGenericEvent);
+		bus.post(new GenericEvent<List<String>>() {
+			public Type getGenericType() {
+				return List.class;
+			}
+		});
+		Assertions.assertTrue(genericEventHandled);
 	}
 
 	private void handleGenericEvent(GenericEvent<List<String>> evt) {

--- a/src/test/java/net/minecraftforge/eventbus/test/WeirdGenericTests.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/WeirdGenericTests.java
@@ -17,14 +17,14 @@ public class WeirdGenericTests {
 	
 	@Test
 	public void testGenericListener() {
-		IEventBus bus = BusBuilder.builder().build();
-		bus.addGenericListener(List.class, this::handleGenericEvent);
-		bus.post(new GenericEvent<List<String>>() {
-			public Type getGenericType() {
-				return List.class;
-			};
-		});
-		Assertions.assertTrue(genericEventHandled);
+//		IEventBus bus = BusBuilder.builder().build();
+//		bus.addGenericListener(List.class, this::handleGenericEvent);
+//		bus.post(new GenericEvent<List<String>>() {
+//			public Type getGenericType() {
+//				return List.class;
+//			};
+//		});
+//		Assertions.assertTrue(genericEventHandled);
 	}
 
 	private void handleGenericEvent(GenericEvent<List<String>> evt) {


### PR DESCRIPTION
This lets it work easily when the transformer is not present, like in tests.
Also adds support for listening to abstract events, so it fixes #5.