### PR TITLE
Fix generic event filter failing when nested type is itself generic

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
@@ -58,6 +58,10 @@ public class ASMEventHandler implements IEventListener
             if (type instanceof ParameterizedType)
             {
                 filter = ((ParameterizedType)type).getActualTypeArguments()[0];
+                if (filter instanceof ParameterizedType) // Unlikely that nested generics will ever be relevant for event filtering, so discard them
+                {
+                	filter = ((ParameterizedType)filter).getRawType();
+                }
             }
         }
     }


### PR DESCRIPTION
When the generic type of a generic event is, in itself, generic, the `filter` ends up being a `ParameterizedType` which will never `==` the raw type of the event. So simply discard that generic information, it would never be useful in practice anyways as no event impl could provide a usable parameterized type.