### PR TITLE
Fix generic listeners not accepting nested generics

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -135,7 +135,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
         return e-> !e.isCancelable() || ignored || !e.isCanceled();
     }
 
-    private <T extends GenericEvent<F>, F> Predicate<T> passGenericFilter(Class<F> type) {
+    private <T extends GenericEvent<? extends F>, F> Predicate<T> passGenericFilter(Class<F> type) {
         return e->e.getGenericType() == type;
     }
 
@@ -160,22 +160,22 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     @Override
-    public <T extends GenericEvent<F>, F> void addGenericListener(final Class<F> genericClassFilter, final Consumer<T> consumer) {
+    public <T extends GenericEvent<? extends F>, F> void addGenericListener(final Class<F> genericClassFilter, final Consumer<T> consumer) {
         addGenericListener(genericClassFilter, EventPriority.NORMAL, consumer);
     }
 
     @Override
-    public <T extends GenericEvent<F>, F> void addGenericListener(final Class<F> genericClassFilter, final EventPriority priority, final Consumer<T> consumer) {
+    public <T extends GenericEvent<? extends F>, F> void addGenericListener(final Class<F> genericClassFilter, final EventPriority priority, final Consumer<T> consumer) {
         addGenericListener(genericClassFilter, priority, false, consumer);
     }
 
     @Override
-    public <T extends GenericEvent<F>, F> void addGenericListener(final Class<F> genericClassFilter, final EventPriority priority, final boolean receiveCancelled, final Consumer<T> consumer) {
+    public <T extends GenericEvent<? extends F>, F> void addGenericListener(final Class<F> genericClassFilter, final EventPriority priority, final boolean receiveCancelled, final Consumer<T> consumer) {
         addListener(priority, passGenericFilter(genericClassFilter).and(passCancelled(receiveCancelled)), consumer);
     }
 
     @Override
-    public <T extends GenericEvent<F>, F> void addGenericListener(final Class<F> genericClassFilter, final EventPriority priority, final boolean receiveCancelled, final Class<T> eventType, final Consumer<T> consumer) {
+    public <T extends GenericEvent<? extends F>, F> void addGenericListener(final Class<F> genericClassFilter, final EventPriority priority, final boolean receiveCancelled, final Class<T> eventType, final Consumer<T> consumer) {
         addListener(priority, passGenericFilter(genericClassFilter).and(passCancelled(receiveCancelled)), eventType, consumer);
     }
 

--- a/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
@@ -15,13 +15,13 @@ public interface IEventBus {
 
     <T extends Event> void addListener(EventPriority priority, boolean receiveCancelled, Class<T> eventType, Consumer<T> consumer);
 
-    <T extends GenericEvent<F>, F> void addGenericListener(Class<F> filter, Consumer<T> consumer);
+    <T extends GenericEvent<? extends F>, F> void addGenericListener(Class<F> filter, Consumer<T> consumer);
 
-    <T extends GenericEvent<F>, F> void addGenericListener(Class<F> filter, EventPriority priority, Consumer<T> consumer);
+    <T extends GenericEvent<? extends F>, F> void addGenericListener(Class<F> filter, EventPriority priority, Consumer<T> consumer);
 
-    <T extends GenericEvent<F>, F> void addGenericListener(Class<F> genericClassFilter, EventPriority priority, boolean receiveCancelled, Consumer<T> consumer);
+    <T extends GenericEvent<? extends F>, F> void addGenericListener(Class<F> genericClassFilter, EventPriority priority, boolean receiveCancelled, Consumer<T> consumer);
 
-    <T extends GenericEvent<F>, F> void addGenericListener(Class<F> genericClassFilter, EventPriority priority, boolean receiveCancelled, Class<T> eventType, Consumer<T> consumer);
+    <T extends GenericEvent<? extends F>, F> void addGenericListener(Class<F> genericClassFilter, EventPriority priority, boolean receiveCancelled, Class<T> eventType, Consumer<T> consumer);
 
     void unregister(Object object);
 

--- a/src/test/java/net/minecraftforge/eventbus/test/WeirdGenericTests.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/WeirdGenericTests.java
@@ -1,0 +1,33 @@
+package net.minecraftforge.eventbus.test;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import net.minecraftforge.eventbus.EventBus;
+import net.minecraftforge.eventbus.api.GenericEvent;
+import net.minecraftforge.eventbus.api.IEventBus;
+
+public class WeirdGenericTests {
+	
+	boolean genericEventHandled = false;
+	
+	@Test
+	public void testGenericListener() {
+		IEventBus bus = new EventBus();
+		bus.addGenericListener(List.class, this::handleGenericEvent);
+		bus.post(new GenericEvent<List<String>>() {
+			public Type getGenericType() {
+				return List.class;
+			};
+		});
+		Assertions.assertTrue(genericEventHandled);
+	}
+
+	private void handleGenericEvent(GenericEvent<List<String>> evt) {
+		genericEventHandled = true;
+	}
+
+}


### PR DESCRIPTION
A simple fix, the root problem goes back to [2015](https://github.com/MinecraftForge/MinecraftForge/issues/2097).

Just change the `GenericEvent` type parameter to `<? extends F>` and all is well. See the new test for an example of why this is necessary.