### PR TITLE
Avoid wrapping exceptions thrown by event listeners

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -253,7 +253,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
             exceptionHandler.handleException(this, event, listeners, index, throwable);
             throw throwable;
         }
-        return (event.isCancelable() ? event.isCanceled() : false);
+        return event.isCancelable() && event.isCanceled();
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -251,7 +251,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
         catch (Throwable throwable)
         {
             exceptionHandler.handleException(this, event, listeners, index, throwable);
-            throw new RuntimeException(throwable);
+            throw throwable;
         }
         return (event.isCancelable() ? event.isCanceled() : false);
     }


### PR DESCRIPTION
This lets exceptions pass through unaltered, so things like `EnhancedRuntimeException` and `ReportedException` can pass through.

It's legal to rethrow the exception here because it is not a checked exception from `IEventListener#invoke`.