### PR TITLE
Add microbenchmark and improve performance of lambda event handler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.ajoberstar.reckon' version '0.9.0'
     id 'org.ajoberstar.grgit' version '3.0.0'
     id 'com.github.ben-manes.versions' version '0.20.0'
+    id 'me.champeau.gradle.jmh' version '0.4.8'
 }
 apply plugin: 'maven'
 apply plugin: 'java-library'
@@ -118,7 +119,29 @@ dependencies {
     api('net.jodah:typetools:0.6.0')
     mlserviceImplementation('cpw.mods:modlauncher:0.10.+:api')
     mlserviceImplementation(sourceSets.main.output)
+    jmhImplementation(sourceSets.mlservice.output)
+    jmhImplementation('cpw.mods:modlauncher:0.10.+')
+    jmhImplementation("org.powermock:powermock-core:2.0.+")
+    jmhImplementation("org.ow2.asm:asm:6.2")
+    jmhImplementation("org.ow2.asm:asm-tree:6.2")
+    jmhImplementation("org.ow2.asm:asm-commons:6.2")
+    jmh("org.ow2.asm:asm:6.2")
 }
+
+jmh {
+    jvmArgs = ['-Djmh.separateClasspathJAR=true']
+    include = [ 'net.minecraftforge.eventbus.benchmarks.EventBusBenchmark' ]
+    benchmarkMode = ['avgt' ]
+    profilers = [ 'stack' ]
+    timeOnIteration = '3s'
+    warmup = '3s'
+    warmupIterations = 3
+    iterations = 3
+    fork = 3
+    timeUnit = 'us'
+}
+
+tasks['jmh'].dependsOn(clean)
 
 artifacts {
     archives jar

--- a/src/jmh/java/net/minecraftforge/eventbus/benchmarks/EventBusBenchmark.java
+++ b/src/jmh/java/net/minecraftforge/eventbus/benchmarks/EventBusBenchmark.java
@@ -1,0 +1,139 @@
+package net.minecraftforge.eventbus.benchmarks;
+
+import cpw.mods.modlauncher.ClassTransformer;
+import cpw.mods.modlauncher.LaunchPluginHandler;
+import cpw.mods.modlauncher.TransformStore;
+import cpw.mods.modlauncher.TransformingClassLoader;
+import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
+import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.service.ModLauncherService;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.powermock.reflect.Whitebox;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static cpw.mods.modlauncher.api.LamdbaExceptionUtils.uncheck;
+
+@State(Scope.Benchmark)
+public class EventBusBenchmark
+{
+    private IEventBus dynamicSubscriberBus;
+    private IEventBus lambdaSubscriberBus;
+    private IEventBus staticSubscriberBus;
+    private Supplier<Event> cancableConstructor;
+    private Supplier<Event> resultConstructor;
+    private Supplier<Event> simpleConstructor;
+
+    @SuppressWarnings("unchecked")
+    @Setup
+    public void setup()
+    {
+        String packageName = "net/minecraftforge/eventbus/benchmarks/compiled/";
+        String[] toTransform = new String[]{"CancelableEvent", "ResultEvent", "SimpleEvent", "SubscriberDynamic", "SubscriberLambda", "SubscriberStatic"};
+        Class<?>[] classes = new Class[toTransform.length];
+
+        //Setup class transformers
+        final TransformStore transformStore = new TransformStore();
+        final LaunchPluginHandler lph = new LaunchPluginHandler();
+        ClassTransformer classTransformer = uncheck(()->Whitebox.invokeConstructor(ClassTransformer.class, new Class[] { transformStore.getClass(),  lph.getClass(), TransformingClassLoader.class }, new Object[] { transformStore, lph, null}));
+        Method transform = Whitebox.getMethod(classTransformer.getClass(), "transform", byte[].class, String.class);
+        LaunchPluginHandler pluginHandler = Whitebox.getInternalState(classTransformer, "pluginHandler");
+        Map<String, ILaunchPluginService> plugins = Whitebox.getInternalState(pluginHandler, "plugins");
+        ModLauncherService service = new ModLauncherService();
+        plugins.put(service.name(), service); //Inject it
+
+        //Setup class loader injects
+        Method defineClass = Whitebox.getMethod(ClassLoader.class, "defineClass", String.class, byte[].class, int.class, int.class);
+        //Setup event and subscriber classes
+        for (int i = 0; i < toTransform.length; i++)
+        {
+            String className = toTransform[i];
+            className = packageName + className;
+            byte[] classBytes;
+            try (InputStream is = getClass().getResourceAsStream("/" + className + ".class"))
+            {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                byte[] buf = new byte[1];
+                while (is.read(buf) >= 0)
+                {
+                    bos.write(buf);
+                }
+                classBytes = bos.toByteArray();
+            } catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+            String clsWithDot = className.replace('/', '.');
+            try
+            {
+                classBytes = (byte[]) transform.invoke(classTransformer, classBytes, clsWithDot);
+                classes[i] = (Class) defineClass.invoke(getClass().getClassLoader(), clsWithDot, classBytes, 0, classBytes.length);
+            } catch (ReflectiveOperationException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+        try
+        {
+            cancableConstructor = (Supplier<Event>) classes[0].getDeclaredField("makeNew").get(null);
+            resultConstructor = (Supplier<Event>) classes[1].getDeclaredField("makeNew").get(null);
+            simpleConstructor = (Supplier<Event>) classes[2].getDeclaredField("makeNew").get(null);
+        } catch (ReflectiveOperationException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        //Setup bus and Subscriber
+        dynamicSubscriberBus = BusBuilder.builder().build();
+        lambdaSubscriberBus = BusBuilder.builder().build();
+        staticSubscriberBus = BusBuilder.builder().build();
+        try
+        {
+            dynamicSubscriberBus.register(Whitebox.invokeConstructor(classes[3]));
+            Whitebox.invokeMethod(classes[4], "register", lambdaSubscriberBus);
+            staticSubscriberBus.register(classes[5]);
+        } catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Benchmark
+    public int testDynamic() throws Exception
+    {
+        postAll(dynamicSubscriberBus);
+        return 0;
+    }
+
+    @Benchmark
+    public int testLambda() throws Exception
+    {
+        postAll(lambdaSubscriberBus);
+        return 0;
+    }
+
+    @Benchmark
+    public int testStatic() throws Exception
+    {
+        postAll(staticSubscriberBus);
+        return 0;
+    }
+
+    public void postAll(IEventBus bus)
+    {
+        bus.post(cancableConstructor.get());
+        bus.post(resultConstructor.get());
+        bus.post(simpleConstructor.get());
+    }
+
+}

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -198,7 +198,14 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     private <T extends Event> void addListener(final EventPriority priority, final Predicate<? super T> filter, final Class<T> eventClass, final Consumer<T> consumer) {
-        addToListeners(consumer, eventClass, e->Stream.of(e).map(eventClass::cast).filter(filter).forEach(consumer), priority);
+        addToListeners(consumer, eventClass, e->
+        {
+            T cast = eventClass.cast(e);
+            if (filter.test(cast))
+            {
+                consumer.accept(cast);
+            }
+        }, priority);
     }
 
     private void register(Class<?> eventType, Object target, Method method)
@@ -253,7 +260,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
         {
             for (; index < listeners.length; index++)
             {
-                if (Objects.equals(listeners[index].getClass(), EventPriority.class) && !trackPhases) continue;
+                if (!trackPhases && Objects.equals(listeners[index].getClass(), EventPriority.class)) continue;
                 listeners[index].invoke(event);
             }
         }

--- a/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/CancelableEvent.java
+++ b/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/CancelableEvent.java
@@ -1,0 +1,13 @@
+package net.minecraftforge.eventbus.benchmarks.compiled;
+
+
+import net.minecraftforge.eventbus.api.Cancelable;
+import net.minecraftforge.eventbus.api.Event;
+
+import java.util.function.Supplier;
+
+@Cancelable
+public class CancelableEvent extends Event
+{
+    public static Supplier<Event> makeNew = CancelableEvent::new;
+}

--- a/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/ResultEvent.java
+++ b/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/ResultEvent.java
@@ -1,0 +1,12 @@
+package net.minecraftforge.eventbus.benchmarks.compiled;
+
+
+import net.minecraftforge.eventbus.api.Event;
+
+import java.util.function.Supplier;
+
+@Event.HasResult
+public class ResultEvent extends Event
+{
+    public static Supplier<Event> makeNew = ResultEvent::new;
+}

--- a/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/SimpleEvent.java
+++ b/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/SimpleEvent.java
@@ -1,0 +1,11 @@
+package net.minecraftforge.eventbus.benchmarks.compiled;
+
+
+import net.minecraftforge.eventbus.api.Event;
+
+import java.util.function.Supplier;
+
+public class SimpleEvent extends Event
+{
+    public static Supplier<Event> makeNew = SimpleEvent::new;
+}

--- a/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/SubscriberDynamic.java
+++ b/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/SubscriberDynamic.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.eventbus.benchmarks.compiled;
+
+
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class SubscriberDynamic
+{
+
+    @SubscribeEvent
+    public static void onCancelableEvent(CancelableEvent event)
+    {
+
+    }
+
+    @SubscribeEvent
+    public static void onResultEvent(ResultEvent event)
+    {
+
+    }
+
+    @SubscribeEvent
+    public static void onSimpleEvent(SimpleEvent event)
+    {
+
+    }
+}

--- a/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/SubscriberLambda.java
+++ b/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/SubscriberLambda.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.eventbus.benchmarks.compiled;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+
+public class SubscriberLambda
+{
+
+    public static void register(IEventBus bus)
+    {
+        bus.addListener(SubscriberLambda::onCancelableEvent);
+        bus.addListener(SubscriberLambda::onResultEvent);
+        bus.addListener(SubscriberLambda::onSimpleEvent);
+    }
+
+    public static void onCancelableEvent(CancelableEvent event)
+    {
+
+    }
+
+    public static void onResultEvent(ResultEvent event)
+    {
+
+    }
+
+    public static void onSimpleEvent(SimpleEvent event)
+    {
+
+    }
+}

--- a/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/SubscriberStatic.java
+++ b/src/testJars/java/net/minecraftforge/eventbus/benchmarks/compiled/SubscriberStatic.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.eventbus.benchmarks.compiled;
+
+
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class SubscriberStatic
+{
+
+    @SubscribeEvent
+    public static void onCancelableEvent(CancelableEvent event)
+    {
+
+    }
+
+    @SubscribeEvent
+    public static void onResultEvent(ResultEvent event)
+    {
+
+    }
+
+    @SubscribeEvent
+    public static void onSimpleEvent(SimpleEvent event)
+    {
+
+    }
+}


### PR DESCRIPTION
This adds some microbenchmarks, similar to modlauncher.
The changes in EventBus should make the code do the same, but much faster.
Before:
```
Benchmark                             Mode  Cnt  Score   Error  Units
EventBusBenchmark.testDynamic         avgt    9  0,009 ± 0,002  us/op
EventBusBenchmark.testDynamic:·stack  avgt         NaN            ---
EventBusBenchmark.testLambda          avgt    9  0,246 ± 0,008  us/op
EventBusBenchmark.testLambda:·stack   avgt         NaN            ---
EventBusBenchmark.testStatic          avgt    9  0,035 ± 0,001  us/op
EventBusBenchmark.testStatic:·stack   avgt         NaN            ---
```
After:
```
Benchmark                             Mode  Cnt  Score    Error  Units
EventBusBenchmark.testDynamic         avgt    9  0,009 ±  0,001  us/op
EventBusBenchmark.testDynamic:·stack  avgt         NaN             ---
EventBusBenchmark.testLambda          avgt    9  0,037 ±  0,002  us/op
EventBusBenchmark.testLambda:·stack   avgt         NaN             ---
EventBusBenchmark.testStatic          avgt    9  0,032 ±  0,001  us/op
EventBusBenchmark.testStatic:·stack   avgt         NaN             ---
```

Stack after:
```
 89,7%  89,7% net.minecraftforge.eventbus.ASMEventHandler.invoke
  5,9%   5,9% net.minecraftforge.eventbus.benchmarks.generated.EventBusBenchmark_testStatic_jmhTest.testStatic_avgt_jmhStub
  3,1%   3,1% net.minecraftforge.eventbus.benchmarks.EventBusBenchmark.testStatic
  0,3%   0,3% net.minecraftforge.eventbus.benchmarks.compiled.SimpleEvent$$Lambda$35/1651988869.get
  0,2%   0,2% net.minecraftforge.eventbus.benchmarks.compiled.ResultEvent$$Lambda$34/141967142.get
  0,2%   0,2% net.minecraftforge.eventbus.benchmarks.compiled.CancelableEvent$$Lambda$33/526889128.get
  0,2%   0,2% net.minecraftforge.eventbus.benchmarks.compiled.ResultEvent$$Lambda$34/508167559.get
  0,1%   0,1% net.minecraftforge.eventbus.benchmarks.compiled.CancelableEvent$$Lambda$33/1749476209.get
  0,1%   0,1% net.minecraftforge.eventbus.benchmarks.compiled.SimpleEvent$$Lambda$35/741590357.get
  0,1%   0,1% net.minecraftforge.eventbus.benchmarks.compiled.SimpleEvent$$Lambda$35/1922543470.get
  0,2%   0,2% <other>
```
dynamic is still much faster than all the others, but I don't see any way to improve this right now