### PR TITLE
Update Event to make metadata fields protected

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/api/Event.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/Event.java
@@ -47,9 +47,9 @@ public class Event
         ALLOW
     }
 
-    private boolean isCanceled = false;
-    private Result result = Result.DEFAULT;
-    private EventPriority phase = null;
+    protected boolean isCanceled = false;
+    protected Result result = Result.DEFAULT;
+    protected EventPriority phase = null;
 
     public Event()
     {


### PR DESCRIPTION
This change would allow events to be pooled and to reset their own metadata fields. For use in [MinecraftForge/pull/5734](https://github.com/MinecraftForge/MinecraftForge/pull/5734) and 