### PR TITLE
Add test for parallel event bus testing

### DIFF
--- a/src/test/java/net/minecraftforge/eventbus/test/ParallelEventTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/ParallelEventTest.java
@@ -1,0 +1,72 @@
+package net.minecraftforge.eventbus.test;
+
+import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.testjar.DummyEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ParallelEventTest
+{
+    private static final int BUS_COUNT = 16;
+    private static final int LISTENER_COUNT = 1000;
+    private static final int RUN_ITERATIONS = 1000;
+
+    private static final AtomicLong COUNTER = new AtomicLong();
+
+    @BeforeEach
+    public void setup() {
+        COUNTER.set(0);
+    }
+
+    @Test()
+    public void testMultipleThreadsMultipleBus() {
+        Set<IEventBus> busSet = new HashSet<>();
+        for (int i = 0; i < BUS_COUNT; i++) {
+            busSet.add(BusBuilder.builder().setTrackPhases(false).build()); //make buses for concurrent testing
+        }
+        busSet.parallelStream().forEach(iEventBus -> { //execute parallel listener adding
+            for (int i = 0; i < LISTENER_COUNT; i++)
+                iEventBus.addListener(this::handle);
+        });
+        busSet.parallelStream().forEach(iEventBus -> { //post events parallel
+            for (int i = 0; i < RUN_ITERATIONS; i++)
+                iEventBus.post(new DummyEvent.GoodEvent());
+        });
+
+        long expected = BUS_COUNT * LISTENER_COUNT * RUN_ITERATIONS;
+        Assertions.assertEquals(COUNTER.get(), expected);
+    }
+
+    @Test
+    public void testMultipleThreadsOneBus() {
+        IEventBus bus = BusBuilder.builder().setTrackPhases(false).build();
+
+        Set<Runnable> toAdd = new HashSet<>();
+
+        for (int i = 0; i < LISTENER_COUNT; i++) { //prepare parallel listener adding
+            toAdd.add(() -> bus.addListener(this::handle));
+        }
+        toAdd.parallelStream().forEach(Runnable::run); //execute parallel listener adding
+
+        toAdd = new HashSet<>();
+        for (int i = 0; i < RUN_ITERATIONS; i++) //prepare parallel event posting
+            toAdd.add(() -> bus.post(new DummyEvent.GoodEvent()));
+        toAdd.parallelStream().forEach(Runnable::run); //post events parallel
+
+        long expected = LISTENER_COUNT * RUN_ITERATIONS;
+        Assertions.assertEquals(COUNTER.get(), expected);
+    }
+
+    private void handle(DummyEvent.GoodEvent event) {
+        synchronized (COUNTER)
+        {
+            COUNTER.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
In an effort to see if https://github.com/MinecraftForge/MinecraftForge/issues/5708 is related to EventBus, I created a new test that registers and posts events parallel on the event bus.
This currently fails almost always on multiple thread that access one bus, I'm still searching where it happens, but when switching `parallelStream` to a regular `stream` it works, so there is a race condition somewhere..