### PR TITLE
Fix EventListenerHelper race condition

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
@@ -47,7 +47,15 @@ public class EventListenerHelper
 
     static ListenerList getListenerListInternal(Class<?> eventClass, boolean fromInstanceCall)
     {
-        return listeners.computeIfAbsent(eventClass, c -> computeListenerList(eventClass, fromInstanceCall));
+        ListenerList list = listeners.get(eventClass);
+        if (list == null)
+        {
+            synchronized (eventClass)
+            {
+                list = listeners.computeIfAbsent(eventClass, c -> computeListenerList(eventClass, fromInstanceCall));
+            }
+        }
+        return list;
     }
 
     private static ListenerList computeListenerList(Class<?> eventClass, boolean fromInstanceCall)


### PR DESCRIPTION
Fixes a race condition in EventListenerHelper.
As this method is called often, I optimized it for the 'ListenerList is present' case, as this is called every time an event is fired.

See #26 for reproduction