### PR TITLE
Add event tags

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
@@ -1,5 +1,8 @@
 package net.minecraftforge.eventbus.api;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import net.minecraftforge.eventbus.EventBus;
 
 /**
@@ -11,6 +14,7 @@ public final class BusBuilder {
     // true by default
     private boolean trackPhases = true;
     private boolean startShutdown = false;
+    private Set<String> tags = new HashSet<>();
 
     public static BusBuilder builder() {
         return new BusBuilder();
@@ -30,12 +34,22 @@ public final class BusBuilder {
         this.startShutdown = true;
         return this;
     }
+    
+    public BusBuilder addTag(String tag) {
+        this.tags.add(tag);
+        return this;
+    }
+    
     public IEventExceptionHandler getExceptionHandler() {
         return exceptionHandler;
     }
 
     public boolean getTrackPhases() {
         return trackPhases;
+    }
+    
+    public Set<String> getTags() {
+        return tags;
     }
 
     public IEventBus build() {

--- a/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
@@ -15,6 +15,7 @@ public final class BusBuilder {
     private boolean trackPhases = true;
     private boolean startShutdown = false;
     private Set<String> tags = new HashSet<>();
+    private boolean checkTagsOnPost = false;
 
     public static BusBuilder builder() {
         return new BusBuilder();
@@ -40,6 +41,11 @@ public final class BusBuilder {
         return this;
     }
     
+    public BusBuilder checkTagsOnPost() {
+        this.checkTagsOnPost = true;
+        return this;
+    }
+    
     public IEventExceptionHandler getExceptionHandler() {
         return exceptionHandler;
     }
@@ -50,6 +56,10 @@ public final class BusBuilder {
     
     public Set<String> getTags() {
         return tags;
+    }
+    
+    public boolean isCheckingTagsOnPost() {
+        return checkTagsOnPost;
     }
 
     public IEventBus build() {

--- a/src/main/java/net/minecraftforge/eventbus/api/Event.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/Event.java
@@ -26,7 +26,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -170,5 +175,20 @@ public class Event
         int prev = phase == null ? -1 : phase.ordinal();
         if (prev >= value.ordinal()) throw new IllegalArgumentException("Attempted to set event phase to "+ value +" when already "+ phase);
         phase = value;
+    }
+    
+    private static final Map<Class<?>, Set<String>> tagCache = new HashMap<>();
+    
+    public final Set<String> getTags()
+    {
+        return getTags(getClass());
+    }
+
+    public static Set<String> getTags(Class<?> eventType)
+    {
+        return tagCache.computeIfAbsent(eventType, cls -> 
+            Arrays.stream(cls.getAnnotationsByType(EventTag.class))
+                .map(EventTag::value)
+                .collect(Collectors.toSet()));
     }
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
@@ -67,7 +67,7 @@ public class EventListenerHelper
 
         try
         {
-            Constructor<?> ctr = eventClass.getConstructor();
+            Constructor<?> ctr = eventClass.getDeclaredConstructor();
             ctr.setAccessible(true);
             Event event = (Event) ctr.newInstance();
             return event.getListenerList();

--- a/src/main/java/net/minecraftforge/eventbus/api/EventTag.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventTag.java
@@ -1,0 +1,30 @@
+package net.minecraftforge.eventbus.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import net.minecraftforge.eventbus.api.EventTag.EventTags;
+
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Repeatable(EventTags.class)
+public @interface EventTag {
+    
+    String value();
+    
+    @Documented
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @interface EventTags {
+        
+        EventTag[] value();
+    }
+}

--- a/src/test/java/net/minecraftforge/eventbus/test/EventTagTests.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/EventTagTests.java
@@ -33,49 +33,57 @@ public class EventTagTests {
         assertThrows(IllegalArgumentException.class, () -> bus.post(event));
     }
     
+    private static IEventBus busWithTags(String... tags) {
+        BusBuilder builder = new BusBuilder().checkTagsOnPost();
+        for (String tag : tags) {
+            builder.addTag(tag);
+        }
+        return builder.build();
+    }
+    
     @Test
     public void testUntaggedEventUntaggedBus() {
-        nonThrowingPost(new BusBuilder().build(), new UntaggedEvent());
+        nonThrowingPost(busWithTags(), new UntaggedEvent());
     }
     
     @Test
     public void testUntaggedEventTaggedBus() {
-        nonThrowingPost(new BusBuilder().addTag(TAG1).build(), new UntaggedEvent());
+        nonThrowingPost(busWithTags(TAG1), new UntaggedEvent());
     }
     
     @Test
     public void testUntaggedEventMultiTaggedBus() {
-        nonThrowingPost(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), new UntaggedEvent());
+        nonThrowingPost(busWithTags(TAG1, TAG2), new UntaggedEvent());
     }
     
     @Test
     public void testTaggedEventUntaggedBus() {
-        throwingPost(new BusBuilder().build(), new TaggedEvent());
+        throwingPost(busWithTags(), new TaggedEvent());
     }
     
     @Test
     public void testTaggedEventTaggedBus() {
-        nonThrowingPost(new BusBuilder().addTag(TAG1).build(), new TaggedEvent());
+        nonThrowingPost(busWithTags(TAG1), new TaggedEvent());
     }
 
     @Test
     public void testTaggedEventMultiTaggedBus() {
-        nonThrowingPost(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), new TaggedEvent());
+        nonThrowingPost(busWithTags(TAG1, TAG2), new TaggedEvent());
     }
     
     @Test
     public void testMultiTaggedEventUntaggedBus() {
-        throwingPost(new BusBuilder().build(), new MultiTaggedEvent());
+        throwingPost(busWithTags(), new MultiTaggedEvent());
     }
     
     @Test
     public void testMultiTaggedEventTaggedBus() {
-        throwingPost(new BusBuilder().addTag(TAG1).build(), new MultiTaggedEvent());
+        throwingPost(busWithTags(TAG1), new MultiTaggedEvent());
     }
 
     @Test
     public void testMultiTaggedEventMultiTaggedBus() {
-        nonThrowingPost(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), new MultiTaggedEvent());
+        nonThrowingPost(busWithTags(TAG1, TAG2), new MultiTaggedEvent());
     }
     
     public void consumeUntaggedEvent(UntaggedEvent event) {}
@@ -92,46 +100,46 @@ public class EventTagTests {
     
     @Test
     public void testUntaggedListenerUntaggedBus() {
-        nonThrowingSubscribe(new BusBuilder().build(), this::consumeUntaggedEvent);
+        nonThrowingSubscribe(busWithTags(), this::consumeUntaggedEvent);
     }
     
     @Test
     public void testUntaggedListenerTaggedBus() {
-        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).build(), this::consumeUntaggedEvent);
+        nonThrowingSubscribe(busWithTags(TAG1), this::consumeUntaggedEvent);
     }
     
     @Test
     public void testUntaggedListenerMultiTaggedBus() {
-        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), this::consumeUntaggedEvent);
+        nonThrowingSubscribe(busWithTags(TAG1, TAG2), this::consumeUntaggedEvent);
     }
     
     @Test
     public void testTaggedListenerUntaggedBus() {
-        throwingSubscribe(new BusBuilder().build(), this::consumeTaggedEvent);
+        throwingSubscribe(busWithTags(), this::consumeTaggedEvent);
     }
     
     @Test
     public void testTaggedListenerTaggedBus() {
-        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).build(), this::consumeTaggedEvent);
+        nonThrowingSubscribe(busWithTags(TAG1), this::consumeTaggedEvent);
     }
     
     @Test
     public void testTaggedListenerMultiTaggedBus() {
-        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), this::consumeTaggedEvent);
+        nonThrowingSubscribe(busWithTags(TAG1, TAG2), this::consumeTaggedEvent);
     }
     
     @Test
     public void testMultiTaggedListenerUntaggedBus() {
-        throwingSubscribe(new BusBuilder().build(), this::consumeMultiTaggedEvent);
+        throwingSubscribe(busWithTags(), this::consumeMultiTaggedEvent);
     }
     
     @Test
     public void testMultiTaggedListenerTaggedBus() {
-        throwingSubscribe(new BusBuilder().addTag(TAG1).build(), this::consumeMultiTaggedEvent);
+        throwingSubscribe(busWithTags(TAG1), this::consumeMultiTaggedEvent);
     }
     
     @Test
     public void testMultiTaggedListenerMultiTaggedBus() {
-        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), this::consumeMultiTaggedEvent);
+        nonThrowingSubscribe(busWithTags(TAG1, TAG2), this::consumeMultiTaggedEvent);
     }
 }

--- a/src/test/java/net/minecraftforge/eventbus/test/EventTagTests.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/EventTagTests.java
@@ -1,0 +1,137 @@
+package net.minecraftforge.eventbus.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventTag;
+import net.minecraftforge.eventbus.api.IEventBus;
+
+public class EventTagTests {
+    
+    private static final String TAG1 = "Foo";
+    private static final String TAG2 = "Bar";
+    
+    private static class UntaggedEvent extends Event {}
+
+    @EventTag(TAG1)
+    private static class TaggedEvent extends Event {}
+
+    @EventTag(TAG1)
+    @EventTag(TAG2)
+    private static class MultiTaggedEvent extends Event {}
+    
+    private static void nonThrowingPost(IEventBus bus, Event event) {
+        assertDoesNotThrow(() -> bus.post(event));
+    }
+    
+    private static void throwingPost(IEventBus bus, Event event) {
+        assertThrows(IllegalArgumentException.class, () -> bus.post(event));
+    }
+    
+    @Test
+    public void testUntaggedEventUntaggedBus() {
+        nonThrowingPost(new BusBuilder().build(), new UntaggedEvent());
+    }
+    
+    @Test
+    public void testUntaggedEventTaggedBus() {
+        nonThrowingPost(new BusBuilder().addTag(TAG1).build(), new UntaggedEvent());
+    }
+    
+    @Test
+    public void testUntaggedEventMultiTaggedBus() {
+        nonThrowingPost(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), new UntaggedEvent());
+    }
+    
+    @Test
+    public void testTaggedEventUntaggedBus() {
+        throwingPost(new BusBuilder().build(), new TaggedEvent());
+    }
+    
+    @Test
+    public void testTaggedEventTaggedBus() {
+        nonThrowingPost(new BusBuilder().addTag(TAG1).build(), new TaggedEvent());
+    }
+
+    @Test
+    public void testTaggedEventMultiTaggedBus() {
+        nonThrowingPost(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), new TaggedEvent());
+    }
+    
+    @Test
+    public void testMultiTaggedEventUntaggedBus() {
+        throwingPost(new BusBuilder().build(), new MultiTaggedEvent());
+    }
+    
+    @Test
+    public void testMultiTaggedEventTaggedBus() {
+        throwingPost(new BusBuilder().addTag(TAG1).build(), new MultiTaggedEvent());
+    }
+
+    @Test
+    public void testMultiTaggedEventMultiTaggedBus() {
+        nonThrowingPost(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), new MultiTaggedEvent());
+    }
+    
+    public void consumeUntaggedEvent(UntaggedEvent event) {}
+    public void consumeTaggedEvent(TaggedEvent event) {}
+    public void consumeMultiTaggedEvent(MultiTaggedEvent event) {}
+    
+    private static <T extends Event> void nonThrowingSubscribe(IEventBus bus, Consumer<T> listener) {
+        assertDoesNotThrow(() -> bus.addListener(listener));
+    }
+    
+    private static <T extends Event> void throwingSubscribe(IEventBus bus, Consumer<T> listener) {
+        assertThrows(IllegalArgumentException.class, () -> bus.addListener(listener));
+    }
+    
+    @Test
+    public void testUntaggedListenerUntaggedBus() {
+        nonThrowingSubscribe(new BusBuilder().build(), this::consumeUntaggedEvent);
+    }
+    
+    @Test
+    public void testUntaggedListenerTaggedBus() {
+        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).build(), this::consumeUntaggedEvent);
+    }
+    
+    @Test
+    public void testUntaggedListenerMultiTaggedBus() {
+        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), this::consumeUntaggedEvent);
+    }
+    
+    @Test
+    public void testTaggedListenerUntaggedBus() {
+        throwingSubscribe(new BusBuilder().build(), this::consumeTaggedEvent);
+    }
+    
+    @Test
+    public void testTaggedListenerTaggedBus() {
+        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).build(), this::consumeTaggedEvent);
+    }
+    
+    @Test
+    public void testTaggedListenerMultiTaggedBus() {
+        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), this::consumeTaggedEvent);
+    }
+    
+    @Test
+    public void testMultiTaggedListenerUntaggedBus() {
+        throwingSubscribe(new BusBuilder().build(), this::consumeMultiTaggedEvent);
+    }
+    
+    @Test
+    public void testMultiTaggedListenerTaggedBus() {
+        throwingSubscribe(new BusBuilder().addTag(TAG1).build(), this::consumeMultiTaggedEvent);
+    }
+    
+    @Test
+    public void testMultiTaggedListenerMultiTaggedBus() {
+        nonThrowingSubscribe(new BusBuilder().addTag(TAG1).addTag(TAG2).build(), this::consumeMultiTaggedEvent);
+    }
+}


### PR DESCRIPTION
Event tags are a system to prevent events being mis-assigned to a bus. This is most commonly seen in forge where a mod event listener is registered to the game bus, or vice-versa.

The system adds a simple `Set<String>` on the `EventBus` which contains the "tags" a bus has. Events declare their tags via an inherited, repeatable annotation `@EventTag`. An event listener can only be registered to a bus that has a super-set of the tags on the event. 

The event bus can also check for tags on each post, but this is disabled by default for performance reasons. The thought being that it is useful for debugging that your events aren't being posted to the wrong bus, but is not very useful in production, so it can be left out there. Simply call `BusBuilder#checkTagsOnPost` to enable it.

Examples of use can be seen in `EventTagTests`

Draft for now due to lack of docs, want to finalize the API first. Feedback welcome!