### PR TITLE
Update EventSubclassTransformer to use static initialization

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
@@ -157,7 +157,7 @@ public class EventSubclassTransformer
         /* Add:
          *     private static volatile ListenerList LISTENER_LIST;
          */
-        classNode.fields.add(new FieldNode(ACC_PRIVATE | ACC_STATIC | ACC_VOLATILE, "LISTENER_LIST", listDesc, null, null));
+        classNode.fields.add(new FieldNode(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "LISTENER_LIST", listDesc, null, null));
 
         /* Add:
          *     static

--- a/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
@@ -155,7 +155,7 @@ public class EventSubclassTransformer
         }
 
         /* Add:
-         *     private static volatile ListenerList LISTENER_LIST;
+         *     private static final ListenerList LISTENER_LIST;
          */
         classNode.fields.add(new FieldNode(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "LISTENER_LIST", listDesc, null, null));
 

--- a/src/main/java/net/minecraftforge/eventbus/Names.java
+++ b/src/main/java/net/minecraftforge/eventbus/Names.java
@@ -5,4 +5,5 @@ class Names {
     static final String HAS_RESULT = "Lnet/minecraftforge/eventbus/api/Event$HasResult;";
     static final String CANCELLABLE = "Lnet/minecraftforge/eventbus/api/Cancelable;";
     static final String LISTENER_LIST = "Lnet/minecraftforge/eventbus/ListenerList;";
+    static final String LISTENER_LIST_HELPER = "Lnet/minecraftforge/eventbus/api/EventListenerHelper;";
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/Event.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/Event.java
@@ -134,6 +134,7 @@ public class Event
      * Called by the base constructor, this is used by ASM generated
      * event classes to setup various functionality such as the listener list.
      */
+    @Deprecated //Unused by ASM generated code, kept for compatibility until we break version
     protected void setup()
     {
     }
@@ -153,6 +154,7 @@ public class Event
         return EventListenerHelper.getListenerListInternal(this.getClass(), true);
     }
 
+    @Deprecated //Unused by ASM generated code, kept for compatibility until we break version
     protected ListenerList getParentListenerList()
     {
         return EventListenerHelper.getListenerListInternal(this.getClass().getSuperclass(), false);

--- a/src/test/java/net/minecraftforge/eventbus/test/AbstractEventListenerTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/AbstractEventListenerTest.java
@@ -3,6 +3,7 @@ package net.minecraftforge.eventbus.test;
 import net.minecraftforge.eventbus.ListenerList;
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventListenerHelper;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import org.junit.jupiter.api.Test;
@@ -12,76 +13,60 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AbstractEventListenerTest {
-	@Test
-	void eventHandlersCanSubscribeToAbstractEvents() {
-		IEventBus bus = BusBuilder.builder().build();
-		AtomicBoolean abstractSuperEventHandled = new AtomicBoolean(false);
-		AtomicBoolean concreteSuperEventHandled = new AtomicBoolean(false);
-		AtomicBoolean abstractSubEventHandled = new AtomicBoolean(false);
-		AtomicBoolean concreteSubEventHandled = new AtomicBoolean(false);
-		bus.addListener(EventPriority.NORMAL, false, AbstractSuperEvent.class, (event) -> abstractSuperEventHandled.set(true));
-		bus.addListener(EventPriority.NORMAL, false, ConcreteSuperEvent.class, (event) -> concreteSuperEventHandled.set(true));
-		bus.addListener(EventPriority.NORMAL, false, AbstractSubEvent.class, (event) -> abstractSubEventHandled.set(true));
-		bus.addListener(EventPriority.NORMAL, false, ConcreteSubEvent.class, (event) -> concreteSubEventHandled.set(true));
+    @Test
+    void eventHandlersCanSubscribeToAbstractEvents() {
+        IEventBus bus = BusBuilder.builder().build();
+        AtomicBoolean abstractSuperEventHandled = new AtomicBoolean(false);
+        AtomicBoolean concreteSuperEventHandled = new AtomicBoolean(false);
+        AtomicBoolean abstractSubEventHandled = new AtomicBoolean(false);
+        AtomicBoolean concreteSubEventHandled = new AtomicBoolean(false);
+        bus.addListener(EventPriority.NORMAL, false, AbstractSuperEvent.class, (event) -> abstractSuperEventHandled.set(true));
+        bus.addListener(EventPriority.NORMAL, false, ConcreteSuperEvent.class, (event) -> concreteSuperEventHandled.set(true));
+        bus.addListener(EventPriority.NORMAL, false, AbstractSubEvent.class, (event) -> abstractSubEventHandled.set(true));
+        bus.addListener(EventPriority.NORMAL, false, ConcreteSubEvent.class, (event) -> concreteSubEventHandled.set(true));
 
-		bus.post(new ConcreteSubEvent());
+        bus.post(new ConcreteSubEvent());
 
-		assertTrue(abstractSuperEventHandled.get(), "handled abstract super event");
-		assertTrue(concreteSuperEventHandled.get(), "handled concrete super event");
-		assertTrue(abstractSubEventHandled.get(), "handled abstract sub event");
-		assertTrue(concreteSubEventHandled.get(), "handled concrete sub event");
-	}
+        assertTrue(abstractSuperEventHandled.get(), "handled abstract super event");
+        assertTrue(concreteSuperEventHandled.get(), "handled concrete super event");
+        assertTrue(abstractSubEventHandled.get(), "handled abstract sub event");
+        assertTrue(concreteSubEventHandled.get(), "handled concrete sub event");
+        assertTrue(ConcreteSubEvent.MERGED_STATIC_INIT == 100, "static init merge failed");
+    }
 
-	// Below, we simulate the things that are added by EventSubclassTransformer
-	// to show that it will work alongside the static listener map.
+    // Below, we simulate the things that are added by EventSubclassTransformer
+    // to show that it will work alongside the static listener map.
 
-	public static abstract class AbstractSuperEvent extends Event {
+    public static abstract class AbstractSuperEvent extends Event {
 
-	}
+    }
 
-	public static class ConcreteSuperEvent extends AbstractSuperEvent {
+    public static class ConcreteSuperEvent extends AbstractSuperEvent {
 
-		private static ListenerList LISTENER_LIST;
-		public ConcreteSuperEvent() {}
+        private static ListenerList LISTENER_LIST = new ListenerList(EventListenerHelper.getListenerList(ConcreteSuperEvent.class.getSuperclass()));
+        public ConcreteSuperEvent() {}
 
-		@Override
-		protected void setup()
-		{
-			super.setup();
-			if (LISTENER_LIST != null)
-				return;
-			LISTENER_LIST = new ListenerList(this.getParentListenerList());
-		}
+        @Override
+        public ListenerList getListenerList()
+        {
+            return LISTENER_LIST;
+        }
+    }
 
-		@Override
-		public ListenerList getListenerList()
-		{
-			return LISTENER_LIST;
-		}
-	}
+    public static class AbstractSubEvent extends ConcreteSuperEvent {
 
-	public static class AbstractSubEvent extends ConcreteSuperEvent {
+    }
 
-	}
+    public static class ConcreteSubEvent extends AbstractSubEvent {
+        protected static int MERGED_STATIC_INIT = 100;
+        private static ListenerList LISTENER_LIST = new ListenerList(EventListenerHelper.getListenerList(ConcreteSubEvent.class.getSuperclass()));
+        public ConcreteSubEvent() {}
 
-	public static class ConcreteSubEvent extends AbstractSubEvent {
-		private static ListenerList LISTENER_LIST;
-		public ConcreteSubEvent() {}
-
-		@Override
-		protected void setup()
-		{
-			super.setup();
-			if (LISTENER_LIST != null)
-				return;
-			LISTENER_LIST = new ListenerList(this.getParentListenerList());
-		}
-
-		@Override
-		public ListenerList getListenerList()
-		{
-			return LISTENER_LIST;
-		}
-	}
+        @Override
+        public ListenerList getListenerList()
+        {
+            return LISTENER_LIST;
+        }
+    }
 
 }


### PR DESCRIPTION
Update EventSubclassTransformer to use static initialization for the synthetic LISTENER_LIST field.

This is guaranteed to be thread safe by the Java spec: https://docs.oracle.com/javase/specs/jls/se8/html/jls-12.html#jls-12.4.2

Pushed as a PR so that others can test it before I pushed.
And because I am running into a phantom test failure related to classloader leaking. It only happens in eclipse junit debug mode.
However gradle passes all tests fine.

Things to note:

I'm pretty sure technically we can remove getParentListenerList completely. As the parent list is managed in the helper now. And no code, not even the transformed code calls this.

Same goes for setup() which was added as a necessity for the listener list creation. But now that we use `<clinit>` we don't need it anymore.