### PR TITLE
Allow event bus to have a base type that all listener parameters must inherit from

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -44,25 +44,29 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     private final int busID = maxID.getAndIncrement();
     private final IEventExceptionHandler exceptionHandler;
     private volatile boolean shutdown = false;
+    
+    private final Class<? extends Event> baseType;
 
     private EventBus()
     {
         ListenerList.resize(busID + 1);
         exceptionHandler = this;
         this.trackPhases = true;
+        this.baseType = Event.class;
     }
 
-    private EventBus(final IEventExceptionHandler handler, boolean trackPhase, boolean startShutdown)
+    private EventBus(final IEventExceptionHandler handler, boolean trackPhase, boolean startShutdown, Class<? extends Event> baseType)
     {
         ListenerList.resize(busID + 1);
         if (handler == null) exceptionHandler = this;
         else exceptionHandler = handler;
         this.trackPhases = trackPhase;
         this.shutdown = startShutdown;
+        this.baseType = baseType;
     }
 
     public EventBus(final BusBuilder busBuilder) {
-        this(busBuilder.getExceptionHandler(), busBuilder.getTrackPhases(), busBuilder.isStartingShutdown());
+        this(busBuilder.getExceptionHandler(), busBuilder.getTrackPhases(), busBuilder.isStartingShutdown(), busBuilder.getBaseType());
     }
 
     private void registerClass(final Class<?> clazz) {
@@ -134,6 +138,12 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
                     "Method " + method + " has @SubscribeEvent annotation, " +
                             "but takes an argument that is not an Event subtype : " + eventType);
         }
+        if (baseType != Event.class && !baseType.isAssignableFrom(eventType))
+        {
+            throw new IllegalArgumentException(
+                    "Method " + method + " has @SubscribeEvent annotation, " +
+                            "but takes an argument that is not a subtype of the base type " + baseType + ": " + eventType);
+        }
 
         register(eventType, target, real);
     }
@@ -201,6 +211,10 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     private <T extends Event> void addListener(final EventPriority priority, final Predicate<? super T> filter, final Class<T> eventClass, final Consumer<T> consumer) {
+        if (baseType != Event.class && !baseType.isAssignableFrom(eventClass)) {
+            throw new IllegalArgumentException(
+                    "Listener for event " + eventClass + " takes an argument that is not a subtype of the base type " + baseType);
+        }
         addToListeners(consumer, eventClass, e-> doCastFilter(filter, eventClass, consumer, e), priority);
     }
 

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -23,7 +23,6 @@ import net.jodah.typetools.TypeResolver;
 import net.minecraftforge.eventbus.api.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.util.Booleans;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -41,7 +40,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     private static AtomicInteger maxID = new AtomicInteger(0);
     private final boolean trackPhases;
 
-    private final boolean checkTypesOnDispatch = Booleans.parseBoolean(System.getProperty("eventbus.checkTypesOnDispatch"), false);
+    private final boolean checkTypesOnDispatch = Boolean.parseBoolean(System.getProperty("eventbus.checkTypesOnDispatch"));
 
     private ConcurrentHashMap<Object, List<IEventListener>> listeners = new ConcurrentHashMap<>();
     private final int busID = maxID.getAndIncrement();

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -23,6 +23,7 @@ import net.jodah.typetools.TypeResolver;
 import net.minecraftforge.eventbus.api.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.util.Booleans;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -39,6 +40,8 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     private static final Logger LOGGER = LogManager.getLogger();
     private static AtomicInteger maxID = new AtomicInteger(0);
     private final boolean trackPhases;
+
+    private final boolean checkTypesOnDispatch = Booleans.parseBoolean(System.getProperty("eventbus.checkTypesOnDispatch"), false);
 
     private ConcurrentHashMap<Object, List<IEventListener>> listeners = new ConcurrentHashMap<>();
     private final int busID = maxID.getAndIncrement();
@@ -261,6 +264,10 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     public boolean post(Event event)
     {
         if (shutdown) return false;
+        if (checkTypesOnDispatch && !baseType.isInstance(event))
+        {
+            throw new IllegalArgumentException("Cannot post event of type " + event.getClass().getSimpleName() + " to this event. Must match type: " + baseType.getSimpleName());
+        }
 
         IEventListener[] listeners = event.getListenerList().getListeners(busID);
         int index = 0;

--- a/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
@@ -11,7 +11,7 @@ public final class BusBuilder {
     // true by default
     private boolean trackPhases = true;
     private boolean startShutdown = false;
-    private Class<? extends Event> baseType;
+    private Class<? extends Event> baseType = Event.class;
 
     public static BusBuilder builder() {
         return new BusBuilder();

--- a/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
@@ -11,6 +11,7 @@ public final class BusBuilder {
     // true by default
     private boolean trackPhases = true;
     private boolean startShutdown = false;
+    private Class<? extends Event> baseType;
 
     public static BusBuilder builder() {
         return new BusBuilder();
@@ -30,6 +31,12 @@ public final class BusBuilder {
         this.startShutdown = true;
         return this;
     }
+    
+    public BusBuilder baseType(Class<? extends Event> type) {
+        this.baseType = type;
+        return this;
+    }
+    
     public IEventExceptionHandler getExceptionHandler() {
         return exceptionHandler;
     }
@@ -44,5 +51,9 @@ public final class BusBuilder {
 
     public boolean isStartingShutdown() {
         return this.startShutdown;
+    }
+    
+    public Class<? extends Event> getBaseType() {
+        return this.baseType;
     }
 }

--- a/src/test/java/net/minecraftforge/eventbus/test/EventChecksTest.java
+++ b/src/test/java/net/minecraftforge/eventbus/test/EventChecksTest.java
@@ -1,0 +1,60 @@
+package net.minecraftforge.eventbus.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.IEventBus;
+
+public class EventChecksTest {
+    
+    public static class BaseEvent extends Event {
+        
+        public BaseEvent() {}
+    }
+    
+    public static class OtherEvent extends Event {
+        
+        public OtherEvent() {}
+    }
+    
+    private static final String PROP_NAME = "eventbus.checkTypesOnDispatch";
+    
+    @BeforeAll
+    public static void setup() {
+        System.setProperty(PROP_NAME, "true");
+    }
+    
+    private static IEventBus bus() {
+        return new BusBuilder().baseType(BaseEvent.class).build();
+    }
+
+    @Test
+    public void testValidType() {
+        IEventBus bus = bus();
+        Assertions.assertDoesNotThrow(() -> bus.addListener((BaseEvent e) -> {}));
+        Assertions.assertDoesNotThrow(() -> bus.post(new BaseEvent()));
+    }
+    
+    @Test
+    public void testInvalidType() {
+        IEventBus bus = bus();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> bus.addListener((OtherEvent e) -> {}));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> bus.post(new OtherEvent()));
+    }
+    
+    @Test
+    public void testSystemProperty() {
+        System.setProperty(PROP_NAME, "false");
+        IEventBus bus = bus();
+        Assertions.assertDoesNotThrow(() -> bus.post(new OtherEvent()));
+    }
+    
+    @AfterAll
+    public static void teardown() {
+        System.clearProperty(PROP_NAME);
+    }
+}


### PR DESCRIPTION
Adds a new method to `BusBuilder`, `baseType`, which sets a `Class` on the bus which filters listeners, and optionally posted events, so that they must inherit from this class. This is intended to be used specifically in Forge, where mod bus and forge bus events are disjoint, but could be used for specialized buses in any project.

If the `eventbus.checkTypesOnDispatch` system property is set to `true`, checks will be performed on post, in addition to the checks done when listeners are added. This is intended to be used in development mode to verify things, but disabled in production environments for maxiumum performance. Will attach JMH benchmarks shortly (have to run them on another computer due to a stupid bug).