### PR TITLE
Fix race condition in ListenerList.resize(int)

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/ListenerList.java
+++ b/src/main/java/net/minecraftforge/eventbus/ListenerList.java
@@ -59,15 +59,17 @@ public class ListenerList
 
     static void resize(int max)
     {
-        if (max <= maxSize)
+        if (max > maxSize)
         {
-            return;
+            synchronized (ListenerList.class)
+            {
+                if (max > maxSize)
+                {
+                    allLists.forEach(list -> list.resizeLists(max));
+                    maxSize = max;
+                }
+            }
         }
-        synchronized (ListenerList.class)
-        {
-            allLists.forEach(list -> list.resizeLists(max));
-        }
-        maxSize = max;
     }
 
     private synchronized void resizeLists(int max)


### PR DESCRIPTION
Lex assures me that the other usage of `maxSize` is not an issue.

### Performance comparison

Baseline (code without my patch):

```
Benchmark                             Mode  Cnt   Score   Error  Units
EventBusBenchmark.testDynamic         avgt    9  30.014 � 0.681  ns/op
EventBusBenchmark.testDynamic:�stack  avgt          NaN            ---
EventBusBenchmark.testLambda          avgt    9  30.809 � 1.349  ns/op
EventBusBenchmark.testLambda:�stack   avgt          NaN            ---
EventBusBenchmark.testStatic          avgt    9  28.793 � 1.591  ns/op
EventBusBenchmark.testStatic:�stack   avgt          NaN            ---
```

With my change:

```
Benchmark                             Mode  Cnt   Score   Error  Units
EventBusBenchmark.testDynamic         avgt    9  30.597 � 1.659  ns/op
EventBusBenchmark.testDynamic:�stack  avgt          NaN            ---
EventBusBenchmark.testLambda          avgt    9  30.219 � 1.016  ns/op
EventBusBenchmark.testLambda:�stack   avgt          NaN            ---
EventBusBenchmark.testStatic          avgt    9  28.783 � 1.441  ns/op
EventBusBenchmark.testStatic:�stack   avgt          NaN            ---
```

Statistically identical, although I presume that method has little representation in these microbenchmarks, so any change probably gets lost in the noise.