### PR TITLE
Provide explicit-class alternative for all addListener methods

### DIFF
--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/EventBusBenchmark.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/EventBusBenchmark.java
@@ -20,6 +20,7 @@ public class EventBusBenchmark {
     private Consumer<Object> postStatic;
     private Consumer<Object> postDynamic;
     private Consumer<Object> postLambda;
+    private Consumer<Object> postClassLambda;
     private Consumer<Object> postCombined;
 
     @SuppressWarnings("unchecked")
@@ -37,6 +38,7 @@ public class EventBusBenchmark {
         postDynamic  = (Consumer<Object>)cls.getField("postDynamic").get(null);
         postLambda   = (Consumer<Object>)cls.getField("postLambda").get(null);
         postCombined = (Consumer<Object>)cls.getField("postCombined").get(null);
+        postClassLambda   = (Consumer<Object>)cls.getField("postClassLambda").get(null);
     }
 
     public static class TestCallback {
@@ -70,6 +72,13 @@ public class EventBusBenchmark {
         return 0;
     }
 
+    @Benchmark
+    public int testModLauncherClassLambda()
+    {
+        postClassLambda.accept(ModLauncher);
+        return 0;
+    }
+
     // ClassLoader ASM Factory
     @Benchmark
     public int testClassLoaderDynamic() throws Throwable {
@@ -92,6 +101,13 @@ public class EventBusBenchmark {
     @Benchmark
     public int testClassLoaderCombined() throws Throwable {
         postCombined.accept(ClassLoader);
+        return 0;
+    }
+
+    @Benchmark
+    public int testClassLoaderClassLambda()
+    {
+        postClassLambda.accept(ClassLoader);
         return 0;
     }
 }

--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/EventBusBenchmarkNoLoader.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/EventBusBenchmarkNoLoader.java
@@ -32,4 +32,10 @@ public class EventBusBenchmarkNoLoader {
         BenchmarkArmsLength.postCombined(BenchmarkArmsLength.NoLoader);
         return 0;
     }
+
+    @Benchmark
+    public int testNoLoaderClassLambda() {
+        BenchmarkArmsLength.postClassLambda(BenchmarkArmsLength.NoLoader);
+        return 0;
+    }
 }

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestModLauncher.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestModLauncher.java
@@ -3,6 +3,7 @@ package net.minecraftforge.eventbus.test;
 import org.junit.jupiter.api.Test;
 
 import net.minecraftforge.eventbus.test.general.AbstractEventListenerTest;
+import net.minecraftforge.eventbus.test.general.ClassLambdaHandlerTest;
 import net.minecraftforge.eventbus.test.general.DeadlockingEventTest;
 import net.minecraftforge.eventbus.test.general.EventBusSubtypeFilterTest;
 import net.minecraftforge.eventbus.test.general.EventFiringEventTest;
@@ -67,6 +68,16 @@ public class TestModLauncher extends TestModLauncherBase {
     @Test
     public void lambdaGenerics() {
         doTest(new LambdaHandlerTest.Generics() {});
+    }
+
+    @Test
+    public void classLambdaBasic() {
+        doTest(new ClassLambdaHandlerTest.Basic() {});
+    }
+
+    @Test
+    public void classLambdaSubClass() {
+        doTest(new ClassLambdaHandlerTest.SubClassEvent() {});
     }
 
     @Disabled

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestNoLoader.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestNoLoader.java
@@ -3,6 +3,7 @@ package net.minecraftforge.eventbus.test;
 import org.junit.jupiter.api.Test;
 
 import net.minecraftforge.eventbus.test.general.AbstractEventListenerTest;
+import net.minecraftforge.eventbus.test.general.ClassLambdaHandlerTest;
 import net.minecraftforge.eventbus.test.general.DeadlockingEventTest;
 import net.minecraftforge.eventbus.test.general.EventBusSubtypeFilterTest;
 import net.minecraftforge.eventbus.test.general.EventFiringEventTest;
@@ -73,6 +74,16 @@ public class TestNoLoader extends TestNoLoaderBase {
     @Test
     public void lambdaGenerics() {
         doTest(new LambdaHandlerTest.Generics() {});
+    }
+
+    @Test
+    public void classLambdaBasic() {
+        doTest(new ClassLambdaHandlerTest.Basic() {});
+    }
+
+    @Test
+    public void classLambdaSubClass() {
+        doTest(new ClassLambdaHandlerTest.SubClassEvent() {});
     }
 
     @Disabled

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/general/ClassLambdaHandlerTest.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/general/ClassLambdaHandlerTest.java
@@ -1,0 +1,69 @@
+package net.minecraftforge.eventbus.test.general;
+
+import net.minecraftforge.eventbus.api.*;
+import net.minecraftforge.eventbus.test.ITestHandler;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class ClassLambdaHandlerTest implements ITestHandler {
+    boolean hit;
+
+    @Override
+    public void before(Consumer<Class<?>> validator, Supplier<BusBuilder> builder) {
+        validator.accept(SubEvent.class);
+        validator.accept(CancellableEvent.class);
+        hit = false;
+    }
+
+    public void consumeEvent(Event e) { hit = true; }
+    public void consumeSubEvent(SubEvent e) { hit = true; }
+
+    public static class Basic extends ClassLambdaHandlerTest
+    {
+        @Override
+        public void test(Consumer<Class<?>> validator, Supplier<BusBuilder> builder) {
+            final IEventBus iEventBus = builder.get().build();
+            // Inline
+            iEventBus.addListener(Event.class, (e)-> hit = true);
+            iEventBus.post(new Event());
+            assertTrue(hit, "Inline Lambda was not called");
+            hit = false;
+            // Method reference
+            iEventBus.addListener(Event.class, this::consumeEvent);
+            iEventBus.post(new Event());
+            assertTrue(hit, "Method reference was not called");
+            hit = false;
+        }
+    }
+
+    public static class SubClassEvent extends ClassLambdaHandlerTest
+    {
+        @Override
+        public void test(Consumer<Class<?>> validator, Supplier<BusBuilder> builder) {
+            final IEventBus iEventBus = builder.get().build();
+            // Inline
+            iEventBus.addListener(SubEvent.class, (e) -> hit = true);
+            iEventBus.post(new SubEvent());
+            assertTrue(hit, "Inline was not called");
+            hit = false;
+            iEventBus.post(new Event());
+            assertTrue(!hit, "Inline was called on root event");
+            // Method Reference
+            iEventBus.addListener(SubEvent.class, this::consumeSubEvent);
+            iEventBus.post(new SubEvent());
+            assertTrue(hit, "Method reference was not called");
+            hit = false;
+            iEventBus.post(new Event());
+            assertTrue(!hit, "Method reference was called on root event");
+        }
+    }
+
+    public static class SubEvent extends Event {}
+
+    @Cancelable
+    public static class CancellableEvent extends Event {}
+}

--- a/eventbus-testjars/src/main/java/net/minecraftforge/eventbus/benchmarks/compiled/BenchmarkArmsLength.java
+++ b/eventbus-testjars/src/main/java/net/minecraftforge/eventbus/benchmarks/compiled/BenchmarkArmsLength.java
@@ -11,7 +11,8 @@ public class BenchmarkArmsLength
         IEventBus staticSubscriberBus,
         IEventBus dynamicSubscriberBus,
         IEventBus lambdaSubscriberBus,
-        IEventBus combinedSubscriberBus
+        IEventBus combinedSubscriberBus,
+        IEventBus classLambdaSubscriberBus
     ) {
         public Bus register() {
             staticSubscriberBus.register(SubscriberStatic.class);
@@ -20,6 +21,7 @@ public class BenchmarkArmsLength
             combinedSubscriberBus.register(new SubscriberDynamic());
             SubscriberLambda.register(lambdaSubscriberBus);
             SubscriberLambda.register(combinedSubscriberBus);
+            SubscriberClassLambda.register(classLambdaSubscriberBus);
             return this;
         }
     };
@@ -36,9 +38,11 @@ public class BenchmarkArmsLength
                 BusBuilder.builder().useModLauncher().build(),
                 BusBuilder.builder().useModLauncher().build(),
                 BusBuilder.builder().useModLauncher().build(),
+                BusBuilder.builder().useModLauncher().build(),
                 BusBuilder.builder().useModLauncher().build()
             ).register();
             ClassLoader = new Bus(
+                BusBuilder.builder().build(),
                 BusBuilder.builder().build(),
                 BusBuilder.builder().build(),
                 BusBuilder.builder().build(),
@@ -53,6 +57,7 @@ public class BenchmarkArmsLength
         BusBuilder.builder().build(),
         BusBuilder.builder().build(),
         BusBuilder.builder().build(),
+        BusBuilder.builder().build(),
         BusBuilder.builder().build()
     ).register();
 
@@ -60,6 +65,7 @@ public class BenchmarkArmsLength
     public static final Consumer<Object> postDynamic = BenchmarkArmsLength::postDynamic;
     public static final Consumer<Object> postLambda = BenchmarkArmsLength::postLambda;
     public static final Consumer<Object> postCombined = BenchmarkArmsLength::postCombined;
+    public static final Consumer<Object> postClassLambda = BenchmarkArmsLength::postLambda;
 
     public static void postStatic(Object bus)
     {
@@ -79,6 +85,11 @@ public class BenchmarkArmsLength
     public static void postCombined(Object bus)
     {
         postAll(((Bus)bus).combinedSubscriberBus);
+    }
+
+    public static void postClassLambda(Object bus)
+    {
+        postAll(((Bus)bus).classLambdaSubscriberBus);
     }
 
     private static void postAll(IEventBus bus)

--- a/eventbus-testjars/src/main/java/net/minecraftforge/eventbus/benchmarks/compiled/SubscriberClassLambda.java
+++ b/eventbus-testjars/src/main/java/net/minecraftforge/eventbus/benchmarks/compiled/SubscriberClassLambda.java
@@ -1,0 +1,29 @@
+package net.minecraftforge.eventbus.benchmarks.compiled;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+
+public class SubscriberClassLambda
+{
+
+    public static void register(IEventBus bus)
+    {
+        bus.addListener(CancelableEvent.class, SubscriberClassLambda::onCancelableEvent);
+        bus.addListener(ResultEvent.class, SubscriberClassLambda::onResultEvent);
+        bus.addListener(EventWithData.class, SubscriberClassLambda::onSimpleEvent);
+    }
+
+    public static void onCancelableEvent(CancelableEvent event)
+    {
+
+    }
+
+    public static void onResultEvent(ResultEvent event)
+    {
+
+    }
+
+    public static void onSimpleEvent(EventWithData event)
+    {
+
+    }
+}

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -188,9 +188,21 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     @Override
+    public <T extends Event> void addListener(final Class<T> eventType, final Consumer<T> consumer) {
+        checkNotGeneric(eventType);
+        addListener(EventPriority.NORMAL, eventType, consumer);
+    }
+
+    @Override
     public <T extends Event> void addListener(final EventPriority priority, final Consumer<T> consumer) {
         checkNotGeneric(consumer);
         addListener(priority, false, consumer);
+    }
+
+    @Override
+    public <T extends Event> void addListener(final EventPriority priority, final Class<T> eventType, final Consumer<T> consumer) {
+        checkNotGeneric(eventType);
+        addListener(priority, false, eventType, consumer);
     }
 
     @Override
@@ -211,8 +223,18 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     @Override
+    public <T extends GenericEvent<? extends F>, F> void addGenericListener(final Class<F> genericClassFilter, final Class<T> eventType, final Consumer<T> consumer) {
+        addGenericListener(genericClassFilter, EventPriority.NORMAL, eventType, consumer);
+    }
+
+    @Override
     public <T extends GenericEvent<? extends F>, F> void addGenericListener(final Class<F> genericClassFilter, final EventPriority priority, final Consumer<T> consumer) {
         addGenericListener(genericClassFilter, priority, false, consumer);
+    }
+
+    @Override
+    public <T extends GenericEvent<? extends F>, F> void addGenericListener(final Class<F> genericClassFilter, final EventPriority priority, final Class<T> eventType, final Consumer<T> consumer) {
+        addGenericListener(genericClassFilter, priority, false, eventType, consumer);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
@@ -38,6 +38,15 @@ public interface IEventBus {
     <T extends Event> void addListener(Consumer<T> consumer);
 
     /**
+     * Add a consumer listener with default {@link EventPriority#NORMAL} and not recieving cancelled events.
+     *
+     * @param eventType The concrete {@link Event} subclass to subscribe to
+     * @param consumer Callback to invoke when a matching event is received
+     * @param <T> The {@link Event} subclass to listen for
+     */
+    <T extends Event> void addListener(Class<T> eventType, Consumer<T> consumer);
+
+    /**
      * Add a consumer listener with the specified {@link EventPriority} and not receiving cancelled events.
      *
      * @param priority {@link EventPriority} for this listener
@@ -45,6 +54,16 @@ public interface IEventBus {
      * @param <T> The {@link Event} subclass to listen for
      */
     <T extends Event> void addListener(EventPriority priority, Consumer<T> consumer);
+
+    /**
+     * Add a consumer listener with the specified {@link EventPriority} and not receiving cancelled events.
+     *
+     * @param priority {@link EventPriority} for this listener
+     * @param eventType The concrete {@link Event} subclass to subscribe to
+     * @param consumer Callback to invoke when a matching event is received
+     * @param <T> The {@link Event} subclass to listen for
+     */
+    <T extends Event> void addListener(EventPriority priority, Class<T> eventType, Consumer<T> consumer);
 
     /**
      * Add a consumer listener with the specified {@link EventPriority} and potentially cancelled events.
@@ -82,6 +101,18 @@ public interface IEventBus {
     <T extends GenericEvent<? extends F>, F> void addGenericListener(Class<F> genericClassFilter, Consumer<T> consumer);
 
     /**
+     * Add a consumer listener for a {@link GenericEvent} subclass, filtered to only be called for the specified
+     * filter {@link Class}.
+     *
+     * @param genericClassFilter A {@link Class} which the {@link GenericEvent} should be filtered for
+     * @param eventType The concrete {@link Event} subclass to subscribe to
+     * @param consumer Callback to invoke when a matching event is received
+     * @param <T> The {@link GenericEvent} subclass to listen for
+     * @param <F> The {@link Class} to filter the {@link GenericEvent} for
+     */
+    <T extends GenericEvent<? extends F>, F> void addGenericListener(Class<F> genericClassFilter, Class<T> eventType, Consumer<T> consumer);
+
+    /**
      * Add a consumer listener with the specified {@link EventPriority} and not receiving cancelled events,
      * for a {@link GenericEvent} subclass, filtered to only be called for the specified
      * filter {@link Class}.
@@ -93,6 +124,19 @@ public interface IEventBus {
      * @param <F> The {@link Class} to filter the {@link GenericEvent} for
      */
     <T extends GenericEvent<? extends F>, F> void addGenericListener(Class<F> genericClassFilter, EventPriority priority, Consumer<T> consumer);
+
+    /**
+     * Add a consumer listener with the specified {@link EventPriority} and not receiving cancelled events,
+     * for a {@link GenericEvent} subclass, filtered to only be called for the specified
+     * filter {@link Class}.
+     *
+     * @param genericClassFilter A {@link Class} which the {@link GenericEvent} should be filtered for
+     * @param priority {@link EventPriority} for this listener
+     * @param consumer Callback to invoke when a matching event is received
+     * @param <T> The {@link GenericEvent} subclass to listen for
+     * @param <F> The {@link Class} to filter the {@link GenericEvent} for
+     */
+    <T extends GenericEvent<? extends F>, F> void addGenericListener(Class<F> genericClassFilter, EventPriority priority, Class<T> eventType, Consumer<T> consumer);
 
     /**
      * Add a consumer listener with the specified {@link EventPriority} and potentially cancelled events,


### PR DESCRIPTION
Adds variants with explicit event class to all addListener and addGenericListener methods that didn't already have them.
Marks all the overloads without an event class parameter deprecated.
Updates all tests to prefer the new overloads.
