### PR TITLE
Use upstream typetools, fix every event being cancellable, and fix classes that already had a method name called "getListenerList" getting a duplicate method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ allprojects {
         failOnMissingModuleInfo = false
         automaticModule('jmh-core-1.35.jar', 'jmh.core')
         automaticModule('jopt-simple-5.0.4.jar', 'jopt.simple') // TODO: Update ModLauncher to use jopt 6.0-alpha-3+, which sets the module name to 'joptsimple'
-        automaticModule('typetools-0.8.3.jar', 'typetools')
     }
     
     def isNonStable = { String version ->
@@ -101,7 +100,7 @@ dependencies {
     implementation('org.apache.logging.log4j:log4j-api:2.17.1')
     implementation('cpw.mods:modlauncher:10.0.+')
     compileOnly('org.jetbrains:annotations:23.0.0')
-    api('net.jodah:typetools:0.8.+')
+    api('net.jodah:typetools:0.6.+')
 }
 
 publishing {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -6,7 +6,7 @@ open module net.minecraftforge.eventbus {
     requires org.objectweb.asm.tree;
     requires org.apache.logging.log4j;
     requires static org.jetbrains.annotations;
-    requires typetools;
+    requires net.jodah.typetools;
 
     exports net.minecraftforge.eventbus;
     exports net.minecraftforge.eventbus.api;

--- a/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventSubclassTransformer.java
@@ -181,7 +181,7 @@ public class EventSubclassTransformer
                  *      }
                  */
                 MethodNode method = new MethodNode(ACC_PUBLIC, CANCELABLE_M.name(), CANCELABLE_M.desc(), null, null);
-                method.instructions.add(new InsnNode(ICONST_1));
+                method.instructions.add(new InsnNode(ICONST_0));
                 method.instructions.add(new InsnNode(IRETURN));
                 classNode.methods.add(method);
             }
@@ -272,12 +272,16 @@ public class EventSubclassTransformer
          */
         method = classNode.methods.stream().filter(LISTENER_LIST_GET::equals).findFirst().orElse(null);
         if (method == null)
+        {
             method = new MethodNode(ACC_PUBLIC, LISTENER_LIST_GET.name(), LISTENER_LIST_GET.desc(), null, null);
+            classNode.methods.add(method);
+        }
         else
+        {
             clear(method);
+        }
         method.instructions.add(new FieldInsnNode(GETSTATIC, classNode.name, LISTENER_LIST_F.name(), LISTENER_LIST_F.desc()));
         method.instructions.add(new InsnNode(ARETURN));
-        classNode.methods.add(method);
         LOGGER.debug(EVENTBUS, "Event transform complete: {}", classNode.name);
         return true;
     }


### PR DESCRIPTION
Fix every event being cancellable
Fix the EventSubclassTransformer adding a duplicate getListenerList if it already exists
Use the upstream version of typetools since the fix for openjdk 11.0.6 in the fork has been added to upstream and upstream already has an `Automatic-Module-Name`