### PR TITLE
Properly update classNode access flag

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/EventAccessTransformer.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventAccessTransformer.java
@@ -29,8 +29,8 @@ public class EventAccessTransformer {
             } else {
                 LOGGER.debug(EVENTBUS, "Transforming @SubscribeEvent method to public {}.{}", classNode.name, method.name);
                 int access = classNode.access & ~(Opcodes.ACC_PRIVATE | Opcodes.ACC_PROTECTED) | Opcodes.ACC_PUBLIC;
-                if (method.access != access) {
-                    method.access = access;
+                if (classNode.access != access) {
+                    classNode.access = access;
                     changed = true;
                 }
 


### PR DESCRIPTION
The method access flags were updated twice instead of updating the class access flags. This also caused the method having invalid flag combinations, e.g. `ABSTRACT` (`ACC_ABSTRACT` on classes) and `SYNCHRONIZED` (`ACC_SUPER` on classes). This leads to startup errors (i.e. java.lang.ClassFormatError when trying to load the class file later).