### PR TITLE
Adds IEvent interface for Record event support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,15 +86,15 @@ publishing {
 
 allprojects {
     ext.VALID_VMS = [
-        'Adoptium':  [16, 17, 18, 19, 20, 21],
-        'Amazon':    [16, 17, 18, 19, 20, 21],
-        'Azul':      (16..21),
-        'BellSoft':  (16..21),
-        'Graal_VM':  [16, 17,     19, 20, 21],
-        'IBM':       [16, 17, 18, 19, 20    ],
-        'Microsoft': [16, 17,             21],
-        'Oracle':    (16..21),
-        'SAP':       (16..20)
+        'Adoptium':  [17, 18, 19, 20, 21],
+        'Amazon':    [17, 18, 19, 20, 21],
+        'Azul':      (17..21),
+        'BellSoft':  (17..21),
+        'Graal_VM':  [17,     19, 20, 21],
+        'IBM':       [17, 18, 19, 20    ],
+        'Microsoft': [17,             21],
+        'Oracle':    (17..21),
+        'SAP':       (17..20)
     ]
     
     // Tests are expensive to run all variants, so only run if asked to

--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkBase.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkBase.java
@@ -126,8 +126,9 @@ public class BenchmarkBase {
     }
 
     protected void run() {
-        if (run != null);
+        if (run != null) {
             run.run();
+        }
     }
 
     private Runnable get(Class<?> cls, Object inst, String name) throws Exception {

--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkCacheConcurrent.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkCacheConcurrent.java
@@ -25,6 +25,19 @@ public class BenchmarkCacheConcurrent extends BenchmarkBase {
     }
     @Setup(Level.Iteration) public void setupIteration() { super.setupIteration(); }
 
+    @Benchmark public void postDynamicRecord() { run(); }
+    @Benchmark public void postDynamicDozenRecord() { run(); }
+    @Benchmark public void postDynamicHundredRecord() { run(); }
+    @Benchmark public void postLambdaRecord() { run(); }
+    @Benchmark public void postLambdaDozenRecord() { run(); }
+    @Benchmark public void postLambdaHundredRecord() { run(); }
+    @Benchmark public void postStaticRecord() { run(); }
+    @Benchmark public void postStaticDozenRecord() { run(); }
+    @Benchmark public void postStaticHundredRecord() { run(); }
+    @Benchmark public void postMixedRecord() { run(); }
+    @Benchmark public void postMixedDozenRecord() { run(); }
+    @Benchmark public void postMixedHundredRecord() { run(); }
+
     @Benchmark public void postDynamic() { run(); }
     @Benchmark public void postDynamicDozen() { run(); }
     @Benchmark public void postDynamicHundred() { run(); }

--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkCacheCopy.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkCacheCopy.java
@@ -25,6 +25,19 @@ public class BenchmarkCacheCopy extends BenchmarkBase {
     }
     @Setup(Level.Iteration) public void setupIteration() { super.setupIteration(); }
 
+    @Benchmark public void postDynamicRecord() { run(); }
+    @Benchmark public void postDynamicDozenRecord() { run(); }
+    @Benchmark public void postDynamicHundredRecord() { run(); }
+    @Benchmark public void postLambdaRecord() { run(); }
+    @Benchmark public void postLambdaDozenRecord() { run(); }
+    @Benchmark public void postLambdaHundredRecord() { run(); }
+    @Benchmark public void postStaticRecord() { run(); }
+    @Benchmark public void postStaticDozenRecord() { run(); }
+    @Benchmark public void postStaticHundredRecord() { run(); }
+    @Benchmark public void postMixedRecord() { run(); }
+    @Benchmark public void postMixedDozenRecord() { run(); }
+    @Benchmark public void postMixedHundredRecord() { run(); }
+
     @Benchmark public void postDynamic() { run(); }
     @Benchmark public void postDynamicDozen() { run(); }
     @Benchmark public void postDynamicHundred() { run(); }

--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkClassLoader.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkClassLoader.java
@@ -16,6 +16,19 @@ public class BenchmarkClassLoader extends BenchmarkBase {
     @Setup public void setup(BenchmarkParams params) { setupTransformed(params, false); }
     @Setup(Level.Iteration) public void setupIteration() { super.setupIteration(); }
 
+    @Benchmark public void postDynamicRecord() { run(); }
+    @Benchmark public void postDynamicDozenRecord() { run(); }
+    @Benchmark public void postDynamicHundredRecord() { run(); }
+    @Benchmark public void postLambdaRecord() { run(); }
+    @Benchmark public void postLambdaDozenRecord() { run(); }
+    @Benchmark public void postLambdaHundredRecord() { run(); }
+    @Benchmark public void postStaticRecord() { run(); }
+    @Benchmark public void postStaticDozenRecord() { run(); }
+    @Benchmark public void postStaticHundredRecord() { run(); }
+    @Benchmark public void postMixedRecord() { run(); }
+    @Benchmark public void postMixedDozenRecord() { run(); }
+    @Benchmark public void postMixedHundredRecord() { run(); }
+
     @Benchmark public void postDynamic() { run(); }
     @Benchmark public void postDynamicDozen() { run(); }
     @Benchmark public void postDynamicHundred() { run(); }

--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkModLauncher.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkModLauncher.java
@@ -16,6 +16,20 @@ public class BenchmarkModLauncher extends BenchmarkBase {
     @Setup public void setup(BenchmarkParams params) { setupTransformed(params, true); }
     @Setup(Level.Iteration) public void setupIteration() { super.setupIteration(); }
 
+
+    @Benchmark public void postDynamicRecord() { run(); }
+    @Benchmark public void postDynamicDozenRecord() { run(); }
+    @Benchmark public void postDynamicHundredRecord() { run(); }
+    @Benchmark public void postLambdaRecord() { run(); }
+    @Benchmark public void postLambdaDozenRecord() { run(); }
+    @Benchmark public void postLambdaHundredRecord() { run(); }
+    @Benchmark public void postStaticRecord() { run(); }
+    @Benchmark public void postStaticDozenRecord() { run(); }
+    @Benchmark public void postStaticHundredRecord() { run(); }
+    @Benchmark public void postMixedRecord() { run(); }
+    @Benchmark public void postMixedDozenRecord() { run(); }
+    @Benchmark public void postMixedHundredRecord() { run(); }
+
     @Benchmark public void postDynamic() { run(); }
     @Benchmark public void postDynamicDozen() { run(); }
     @Benchmark public void postDynamicHundred() { run(); }

--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkNoLoader.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkNoLoader.java
@@ -16,6 +16,20 @@ public class BenchmarkNoLoader extends BenchmarkBase {
     @Setup public void setup(BenchmarkParams params) { setupNormal(params); }
     @Setup(Level.Iteration) public void setupIteration() { super.setupIteration(); }
 
+
+    @Benchmark public void postDynamicRecord() { run(); }
+    @Benchmark public void postDynamicDozenRecord() { run(); }
+    @Benchmark public void postDynamicHundredRecord() { run(); }
+    @Benchmark public void postLambdaRecord() { run(); }
+    @Benchmark public void postLambdaDozenRecord() { run(); }
+    @Benchmark public void postLambdaHundredRecord() { run(); }
+    @Benchmark public void postStaticRecord() { run(); }
+    @Benchmark public void postStaticDozenRecord() { run(); }
+    @Benchmark public void postStaticHundredRecord() { run(); }
+    @Benchmark public void postMixedRecord() { run(); }
+    @Benchmark public void postMixedDozenRecord() { run(); }
+    @Benchmark public void postMixedHundredRecord() { run(); }
+
     @Benchmark public void postDynamic() { run(); }
     @Benchmark public void postDynamicDozen() { run(); }
     @Benchmark public void postDynamicHundred() { run(); }

--- a/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkWrapped.java
+++ b/eventbus-jmh/src/main/java/net/minecraftforge/eventbus/benchmarks/BenchmarkWrapped.java
@@ -16,6 +16,20 @@ public class BenchmarkWrapped extends BenchmarkBase {
     @Setup public void setup(BenchmarkParams params) { setupWrapped(params); }
     @Setup(Level.Iteration) public void setupIteration() { super.setupIteration(); }
 
+
+    @Benchmark public void postDynamicRecord() { run(); }
+    @Benchmark public void postDynamicDozenRecord() { run(); }
+    @Benchmark public void postDynamicHundredRecord() { run(); }
+    @Benchmark public void postLambdaRecord() { run(); }
+    @Benchmark public void postLambdaDozenRecord() { run(); }
+    @Benchmark public void postLambdaHundredRecord() { run(); }
+    @Benchmark public void postStaticRecord() { run(); }
+    @Benchmark public void postStaticDozenRecord() { run(); }
+    @Benchmark public void postStaticHundredRecord() { run(); }
+    @Benchmark public void postMixedRecord() { run(); }
+    @Benchmark public void postMixedDozenRecord() { run(); }
+    @Benchmark public void postMixedHundredRecord() { run(); }
+
     @Benchmark public void postDynamic() { run(); }
     @Benchmark public void postDynamicDozen() { run(); }
     @Benchmark public void postDynamicHundred() { run(); }

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/TestListener.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/TestListener.java
@@ -5,7 +5,7 @@
 
 package net.minecraftforge.eventbus.testjar;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.IEvent;
 import net.minecraftforge.eventbus.api.IEventListener;
 
 public class TestListener implements IEventListener {
@@ -16,7 +16,7 @@ public class TestListener implements IEventListener {
     }
 
     @Override
-    public void invoke(final Event event) {
+    public void invoke(final IEvent event) {
         instance.equals(event);
     }
 }

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/benchmarks/BenchmarkManager.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/benchmarks/BenchmarkManager.java
@@ -68,6 +68,23 @@ public class BenchmarkManager {
             case "postStatic":        return new Post.Static.Single();
             case "postStaticDozen":   return new Post.Static.Dozen();
             case "postStaticHundred": return new Post.Static.Hundred();
+
+            case "postMixedRecord":        return new PostRecord.Mixed.Single();
+            case "postMixedDozenRecord":   return new PostRecord.Mixed.Dozen();
+            case "postMixedHundredRecord": return new PostRecord.Mixed.Hundred();
+
+            case "postDynamicRecord":        return new PostRecord.Dynamic.Single();
+            case "postDynamicDozenRecord":   return new PostRecord.Dynamic.Dozen();
+            case "postDynamicHundredRecord": return new PostRecord.Dynamic.Hundred();
+
+            case "postLambdaRecord":        return new PostRecord.Lambda.Single();
+            case "postLambdaDozenRecord":   return new PostRecord.Lambda.Dozen();
+            case "postLambdaHundredRecord": return new PostRecord.Lambda.Hundred();
+
+            case "postStaticRecord":        return new PostRecord.Static.Single();
+            case "postStaticDozenRecord":   return new PostRecord.Static.Dozen();
+            case "postStaticHundredRecord": return new PostRecord.Static.Hundred();
+
         }
         throw new IllegalArgumentException("Invalid benchmark: " + name);
     }

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/benchmarks/PostRecord.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/benchmarks/PostRecord.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.eventbus.testjar.benchmarks;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.testjar.events.RecordEvent;
+import net.minecraftforge.eventbus.testjar.subscribers.record.SubscriberDynamic;
+import net.minecraftforge.eventbus.testjar.subscribers.record.SubscriberLambda;
+import net.minecraftforge.eventbus.testjar.subscribers.record.SubscriberStatic;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public abstract class PostRecord implements Benchmark {
+    protected IEventBus bus;
+
+    @Override
+    public void setup(Supplier<IEventBus> busFactory) {
+        this.bus = busFactory.get();
+        register();
+    }
+
+    protected abstract void register();
+
+    @Override
+    public void run() {
+        bus.post(new RecordEvent());
+        bus.post(new RecordEvent());
+        bus.post(new RecordEvent());
+    }
+
+    private static abstract class Dozen extends PostRecord {
+        @Override
+        protected void register() {
+            var factory = factory();
+            for (int x = 0; x < 12; x++)
+                factory.accept(bus);
+        }
+
+        protected abstract Consumer<IEventBus> factory();
+    }
+
+    private static abstract class Hundred extends PostRecord {
+        @Override
+        protected void register() {
+            var factory = factory();
+            for (int x = 0; x < 100; x++)
+                factory.accept(bus);
+        }
+
+        protected abstract Consumer<IEventBus> factory();
+    }
+
+    public static class Mixed {
+        private static final Consumer<IEventBus> register = new Consumer<>() {
+            private int idx = 0;
+            @Override
+            public void accept(IEventBus bus) {
+                switch (idx++ % 3) {
+                    case 0: SubscriberDynamic.Factory.REGISTER.create().accept(bus); break;
+                    case 1: SubscriberStatic.Factory.REGISTER.create().accept(bus); break;
+                    case 2: SubscriberLambda.Factory.REGISTER.create().accept(bus); break;
+                }
+            }
+        };
+
+        public static class Single extends PostRecord {
+            @Override
+            protected void register() {
+                SubscriberDynamic.Factory.REGISTER.create().accept(bus);
+                SubscriberStatic.Factory.REGISTER.create().accept(bus);
+                SubscriberLambda.Factory.REGISTER.create().accept(bus);
+            }
+        }
+
+        public static class Dozen extends PostRecord.Dozen {
+            @Override
+            protected Consumer<IEventBus> factory() {
+                return register;
+            }
+        }
+
+        public static class Hundred extends PostRecord.Hundred {
+            @Override
+            protected Consumer<IEventBus> factory() {
+                return register;
+            }
+        }
+    }
+
+    public static class Dynamic {
+        public static class Single extends PostRecord {
+            @Override
+            protected void register() {
+                SubscriberDynamic.Factory.REGISTER.create().accept(bus);
+            }
+        }
+
+        public static class Dozen extends PostRecord.Dozen {
+            @Override
+            protected Consumer<IEventBus> factory() {
+                return bus -> SubscriberDynamic.Factory.REGISTER.create().accept(bus);
+            }
+        }
+
+        public static class Hundred extends PostRecord.Hundred {
+            @Override
+            protected Consumer<IEventBus> factory() {
+                return bus -> SubscriberDynamic.Factory.REGISTER.create().accept(bus);
+            }
+        }
+    }
+
+    public static class Lambda {
+        public static class Single extends PostRecord {
+            @Override
+            protected void register() {
+                SubscriberLambda.Factory.REGISTER.create().accept(bus);
+            }
+        }
+
+        public static class Dozen extends PostRecord.Dozen {
+            @Override
+            protected Consumer<IEventBus> factory() {
+                return bus -> SubscriberLambda.Factory.REGISTER.create().accept(bus);
+            }
+        }
+
+        public static class Hundred extends PostRecord.Hundred {
+            @Override
+            protected Consumer<IEventBus> factory() {
+                return bus -> SubscriberLambda.Factory.REGISTER.create().accept(bus);
+            }
+        }
+    }
+
+    public static class Static {
+        public static class Single extends PostRecord {
+            @Override
+            protected void register() {
+                SubscriberStatic.Factory.REGISTER.create().accept(bus);
+            }
+        }
+
+        public static class Dozen extends PostRecord.Dozen {
+            @Override
+            protected Consumer<IEventBus> factory() {
+                return bus -> SubscriberStatic.Factory.REGISTER.create().accept(bus);
+            }
+        }
+
+        public static class Hundred extends PostRecord.Hundred {
+            @Override
+            protected Consumer<IEventBus> factory() {
+                return bus -> SubscriberStatic.Factory.REGISTER.create().accept(bus);
+            }
+        }
+    }
+
+
+}

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/events/RecordEvent.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/events/RecordEvent.java
@@ -1,0 +1,6 @@
+package net.minecraftforge.eventbus.testjar.events;
+
+import net.minecraftforge.eventbus.api.IEvent;
+
+public record RecordEvent() implements IEvent {
+}

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/record/SubscriberDynamic.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/record/SubscriberDynamic.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.eventbus.testjar.subscribers.record;
+
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.testjar.benchmarks.ClassFactory;
+import net.minecraftforge.eventbus.testjar.events.CancelableEvent;
+import net.minecraftforge.eventbus.testjar.events.EventWithData;
+import net.minecraftforge.eventbus.testjar.events.RecordEvent;
+import net.minecraftforge.eventbus.testjar.events.ResultEvent;
+
+import java.util.function.Consumer;
+
+public class SubscriberDynamic {
+    @SubscribeEvent
+    public void onEvent(RecordEvent event) {}
+
+    public static class Factory {
+        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>("net.minecraftforge.eventbus.testjar.subscribers.record.SubscriberDynamic", cls -> {
+            var inst = cls.getConstructor().newInstance();
+            return bus -> bus.register(inst);
+        });
+    }
+}

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/record/SubscriberLambda.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/record/SubscriberLambda.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.eventbus.testjar.subscribers.record;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.testjar.benchmarks.ClassFactory;
+import net.minecraftforge.eventbus.testjar.events.RecordEvent;
+
+import java.util.function.Consumer;
+
+public class SubscriberLambda {
+    public static Consumer<IEventBus> register = SubscriberLambda::register;
+    public static void register(IEventBus bus) {
+        bus.addListener(SubscriberLambda::onEvent);
+    }
+
+    public static void onEvent(RecordEvent event) {}
+
+    public static class Factory {
+        @SuppressWarnings("unchecked")
+        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>("net.minecraftforge.eventbus.testjar.subscribers.record.SubscriberLambda", cls -> (Consumer<IEventBus>)cls.getDeclaredField("register").get(null));
+    }
+}

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/record/SubscriberStatic.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/record/SubscriberStatic.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.minecraftforge.eventbus.testjar.subscribers.record;
+
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.eventbus.testjar.benchmarks.ClassFactory;
+import net.minecraftforge.eventbus.testjar.events.CancelableEvent;
+import net.minecraftforge.eventbus.testjar.events.EventWithData;
+import net.minecraftforge.eventbus.testjar.events.RecordEvent;
+import net.minecraftforge.eventbus.testjar.events.ResultEvent;
+
+import java.util.function.Consumer;
+
+public class SubscriberStatic {
+    @SubscribeEvent
+    public static void onEvent(RecordEvent event) {}
+
+    public static class Factory {
+        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>("net.minecraftforge.eventbus.testjar.subscribers.record.SubscriberStatic", cls -> bus -> bus.register(cls));
+    }
+}

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/general/EventFiringEventTest.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/general/EventFiringEventTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.IEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.test.ITestHandler;
@@ -23,16 +24,21 @@ public class EventFiringEventTest implements ITestHandler {
         validator.accept(Event1.class);
         validator.accept(AbstractEvent.class);
         validator.accept(AbstractEvent.Event2.class);
+        validator.accept(Event3.class);
 
         IEventBus bus = builder.get().build();
         AtomicBoolean handled1 = new AtomicBoolean(false);
         AtomicBoolean handled2 = new AtomicBoolean(false);
+        AtomicBoolean handled3 = new AtomicBoolean(false);
         bus.addListener(EventPriority.NORMAL, false, Event1.class, (event1) -> {
             bus.post(new AbstractEvent.Event2());
             handled1.set(true);
         });
         bus.addListener(EventPriority.NORMAL, false, AbstractEvent.Event2.class, (event2) -> {
             handled2.set(true);
+        });
+        bus.addListener(EventPriority.NORMAL, false, Event3.class, (event2) -> {
+            handled3.set(true);
         });
 
         bus.post(new Event1());
@@ -42,6 +48,8 @@ public class EventFiringEventTest implements ITestHandler {
     }
 
     public static class Event1 extends Event {}
+
+    public record Event3() implements IEvent {}
 
     public static abstract class AbstractEvent extends Event {
         public static class Event2 extends AbstractEvent {}

--- a/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
@@ -41,7 +41,7 @@ public class ASMEventHandler implements IEventListener {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public void invoke(Event event) {
+    public void invoke(IEvent event) {
         if (handler != null) {
             if (!event.isCanceled() || subInfo.receiveCanceled()) {
                 if (filter == null || filter == ((IGenericEvent)event).getGenericType())

--- a/src/main/java/net/minecraftforge/eventbus/BusBuilderImpl.java
+++ b/src/main/java/net/minecraftforge/eventbus/BusBuilderImpl.java
@@ -5,7 +5,7 @@
 package net.minecraftforge.eventbus;
 
 import net.minecraftforge.eventbus.api.BusBuilder;
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.IEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.IEventExceptionHandler;
 
@@ -17,7 +17,7 @@ public final class BusBuilderImpl implements BusBuilder {
     boolean trackPhases = true;
     boolean startShutdown = false;
     boolean checkTypesOnDispatch = false;
-    Class<?> markerType = Event.class;
+    Class<?> markerType = IEvent.class;
     boolean modLauncher = false;
 
     @Override

--- a/src/main/java/net/minecraftforge/eventbus/ClassLoaderFactory.java
+++ b/src/main/java/net/minecraftforge/eventbus/ClassLoaderFactory.java
@@ -7,6 +7,8 @@ package net.minecraftforge.eventbus;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+
+import net.minecraftforge.eventbus.api.IEvent;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
@@ -19,7 +21,7 @@ import static org.objectweb.asm.Opcodes.*;
 
 public class ClassLoaderFactory implements IEventListenerFactory {
     private static final String HANDLER_DESC = Type.getInternalName(IEventListener.class);
-    private static final String HANDLER_FUNC_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Event.class));
+    private static final String HANDLER_FUNC_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(IEvent.class));
     private static final ASMClassLoader LOADER = new ASMClassLoader();
     private static final Cache<Method, Class<?>> cache = InternalUtils.cache();
 

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -159,7 +159,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
         register(eventType, target, real);
     }
 
-    private static final Predicate<Event> checkCancelled = e -> !e.isCanceled();
+    private static final Predicate<IEvent> checkCancelled = e -> !e.isCanceled();
     @SuppressWarnings("unchecked")
     private <T extends IEvent> Predicate<T> passCancelled(boolean ignored) {
         return ignored ? null : (Predicate<T>)checkCancelled;

--- a/src/main/java/net/minecraftforge/eventbus/EventBusErrorMessage.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBusErrorMessage.java
@@ -4,7 +4,7 @@
  */
 package net.minecraftforge.eventbus;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.IEvent;
 import net.minecraftforge.eventbus.api.IEventListener;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
@@ -19,7 +19,7 @@ public class EventBusErrorMessage implements Message, StringBuilderFormattable {
     private final IEventListener[] listeners;
     private final Throwable throwable;
 
-    public EventBusErrorMessage(final Event event, final int index, final IEventListener[] listeners, final Throwable throwable) {
+    public EventBusErrorMessage(final IEvent event, final int index, final IEventListener[] listeners, final Throwable throwable) {
         //this.event = event;
         this.index = index;
         this.listeners = listeners;

--- a/src/main/java/net/minecraftforge/eventbus/NamedEventListener.java
+++ b/src/main/java/net/minecraftforge/eventbus/NamedEventListener.java
@@ -4,7 +4,7 @@
  */
 package net.minecraftforge.eventbus;
 
-import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.IEvent;
 import net.minecraftforge.eventbus.api.IEventListener;
 
 import java.util.function.Supplier;
@@ -30,7 +30,7 @@ public class NamedEventListener implements IEventListener {
     }
 
     @Override
-    public void invoke(final Event event) {
+    public void invoke(final IEvent event) {
         this.wrap.invoke(event);
     }
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
@@ -34,12 +34,12 @@ public class EventListenerHelper {
     }
 
     static ListenerList getListenerListInternal(Class<?> eventClass, boolean fromInstanceCall) {
-        if (eventClass == Event.class) return EVENTS_LIST; // Small optimization, bypasses all the locks/maps.
+        if (eventClass == Event.class || eventClass == IEvent.class || eventClass == Object.class) return EVENTS_LIST; // Small optimization, bypasses all the locks/maps.
         return listeners.apply(eventClass, () -> computeListenerList(eventClass, fromInstanceCall));
     }
 
     private static ListenerList computeListenerList(Class<?> eventClass, boolean fromInstanceCall) {
-        if (eventClass == Event.class)
+        if (eventClass == Event.class || eventClass == IEvent.class || eventClass == Object.class)
             return EVENTS_LIST;
 
         if (fromInstanceCall || Modifier.isAbstract(eventClass.getModifiers())) {
@@ -51,7 +51,7 @@ public class EventListenerHelper {
         try {
             Constructor<?> ctr = eventClass.getConstructor();
             ctr.setAccessible(true);
-            Event event = (Event) ctr.newInstance();
+            IEvent event = (IEvent) ctr.newInstance();
             return event.getListenerList();
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException("Error computing listener list for " + eventClass.getName(), e);
@@ -67,7 +67,7 @@ public class EventListenerHelper {
     }
 
     private static boolean hasAnnotation(Class<?> eventClass, Class<? extends Annotation> annotation, BiFunction<Class<?>, Supplier<Boolean>, Boolean> cache) {
-        if (eventClass == Event.class || eventClass == Object.class)
+        if (eventClass == Event.class || eventClass == Object.class || eventClass == IEvent.class)
             return false;
 
         return cache.apply(eventClass, () -> {

--- a/src/main/java/net/minecraftforge/eventbus/api/EventPriority.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventPriority.java
@@ -30,7 +30,7 @@ public enum EventPriority implements IEventListener {
     MONITOR; //Last to execute
 
     @Override
-    public void invoke(Event event) {
+    public void invoke(IEvent event) {
         event.setPhase(this);
     }
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/IEvent.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEvent.java
@@ -92,10 +92,10 @@ public interface IEvent {
 
     @Nullable
     default EventPriority getPhase() {
-        return null;
+        throw new UnsupportedOperationException("Attempted to called Event#getPhase() on an event that does not support phase tracking");
     }
 
     default void setPhase(@NotNull EventPriority value) {
-        throw new UnsupportedOperationException("Attempted to call Event#setPhase() on an event that does not support phases");
+        // No-op because record based events do not support phase tracking
     }
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/IEvent.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEvent.java
@@ -9,32 +9,7 @@ import net.minecraftforge.eventbus.ListenerList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-import java.util.Objects;
-
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-/**
- * Base Event class that all other events are derived from
- */
-public class Event implements IEvent {
-    @Retention(value = RUNTIME)
-    @Target(value = TYPE)
-    public @interface HasResult{}
-
-    public enum Result {
-        DENY,
-        DEFAULT,
-        ALLOW
-    }
-
-    private boolean isCanceled = false;
-    private Result result = Result.DEFAULT;
-    private EventPriority phase = null;
-
-    public Event() { }
+public interface IEvent {
 
     /**
      * Determine if this function is cancelable at all.
@@ -43,16 +18,16 @@ public class Event implements IEvent {
      * Note:
      * Events with the Cancelable annotation will have this method automatically added to return true.
      */
-    public boolean isCancelable() {
-        return EventListenerHelper.isCancelable(this.getClass());
+    default boolean isCancelable() {
+        return false;
     }
 
     /**
      * Determine if this event is canceled and should stop executing.
      * @return The current canceled state
      */
-    public boolean isCanceled() {
-        return isCanceled;
+    default boolean isCanceled() {
+        return false;
     }
 
     /**
@@ -68,19 +43,8 @@ public class Event implements IEvent {
      *
      * @param cancel The new canceled value
      */
-    public void setCanceled(boolean cancel) {
-        if (!isCancelable())
-        {
-            throw new UnsupportedOperationException(
-                "Attempted to call Event#setCanceled() on a non-cancelable event of type: "
-                + this.getClass().getCanonicalName()
-            );
-        }
-
-        if (seenPhase(EventPriority.MONITOR))
-            throw new IllegalStateException("Attempted to call Event#setCanceled() after the MONITOR phase");
-
-        isCanceled = cancel;
+    default void setCanceled(boolean cancel) {
+        throw new UnsupportedOperationException("Attempted to call Event#setCanceled() on a non-cancelable event");
     }
 
     /**
@@ -89,15 +53,15 @@ public class Event implements IEvent {
      * Note:
      * Events with the HasResult annotation will have this method automatically added to return true.
      */
-    public boolean hasResult() {
-        return EventListenerHelper.hasResult(this.getClass());
+    default boolean hasResult() {
+        return false;
     }
 
     /**
      * Returns the value set as the result of this event
      */
-    public Result getResult() {
-        return result;
+    default Event.Result getResult() {
+        return null;
     }
 
     /**
@@ -108,23 +72,30 @@ public class Event implements IEvent {
      *
      * @param value The new result
      */
-    public void setResult(Result value) {
-        result = value;
+    default void setResult(Event.Result value) {
+        throw new UnsupportedOperationException("Attempted to call Event#setResult() on an event that does not support results");
+    }
+
+    /**
+     * Returns a ListenerList object that contains all listeners
+     * that are registered to this event.
+     *
+     * Note: for better efficiency, this gets overridden automatically
+     * using a Transformer, there is no need to override it yourself.
+     * @see EventSubclassTransformer
+     *
+     * @return Listener List
+     */
+    default ListenerList getListenerList() {
+        return EventListenerHelper.getListenerListInternal(this.getClass(), true);
     }
 
     @Nullable
-    public EventPriority getPhase() {
-        return this.phase;
+    default EventPriority getPhase() {
+        return null;
     }
 
-    public void setPhase(@NotNull EventPriority value) {
-        Objects.requireNonNull(value, "setPhase argument must not be null");
-        if (seenPhase(value)) throw new IllegalArgumentException("Attempted to set event phase to "+ value +" when already "+ phase);
-        phase = value;
-    }
-
-    private boolean seenPhase(@NotNull EventPriority value) {
-        int prev = phase == null ? -1 : phase.ordinal();
-        return prev >= value.ordinal();
+    default void setPhase(@NotNull EventPriority value) {
+        throw new UnsupportedOperationException("Attempted to call Event#setPhase() on an event that does not support phases");
     }
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
@@ -37,18 +37,18 @@ public interface IEventBus {
      * Add a consumer listener with default {@link EventPriority#NORMAL} and not recieving cancelled events.
      *
      * @param consumer Callback to invoke when a matching event is received
-     * @param <T> The {@link Event} subclass to listen for
+     * @param <T> The {@link IEvent} subclass to listen for
      */
-    <T extends Event> void addListener(Consumer<T> consumer);
+    <T extends IEvent> void addListener(Consumer<T> consumer);
 
     /**
      * Add a consumer listener with the specified {@link EventPriority} and not receiving cancelled events.
      *
      * @param priority {@link EventPriority} for this listener
      * @param consumer Callback to invoke when a matching event is received
-     * @param <T> The {@link Event} subclass to listen for
+     * @param <T> The {@link IEvent} subclass to listen for
      */
-    <T extends Event> void addListener(EventPriority priority, Consumer<T> consumer);
+    <T extends IEvent> void addListener(EventPriority priority, Consumer<T> consumer);
 
     /**
      * Add a consumer listener with the specified {@link EventPriority} and potentially cancelled events.
@@ -56,23 +56,23 @@ public interface IEventBus {
      * @param priority {@link EventPriority} for this listener
      * @param receiveCancelled Indicate if this listener should receive events that have been {@link Cancelable} cancelled
      * @param consumer Callback to invoke when a matching event is received
-     * @param <T> The {@link Event} subclass to listen for
+     * @param <T> The {@link IEvent} subclass to listen for
      */
-    <T extends Event> void addListener(EventPriority priority, boolean receiveCancelled, Consumer<T> consumer);
+    <T extends IEvent> void addListener(EventPriority priority, boolean receiveCancelled, Consumer<T> consumer);
 
     /**
      * Add a consumer listener with the specified {@link EventPriority} and potentially cancelled events.
      *
-     * Use this method when one of the other methods fails to determine the concrete {@link Event} subclass that is
+     * Use this method when one of the other methods fails to determine the concrete {@link IEvent} subclass that is
      * intended to be subscribed to.
      *
      * @param priority {@link EventPriority} for this listener
      * @param receiveCancelled Indicate if this listener should receive events that have been {@link Cancelable} cancelled
-     * @param eventType The concrete {@link Event} subclass to subscribe to
+     * @param eventType The concrete {@link IEvent} subclass to subscribe to
      * @param consumer Callback to invoke when a matching event is received
-     * @param <T> The {@link Event} subclass to listen for
+     * @param <T> The {@link IEvent} subclass to listen for
      */
-    <T extends Event> void addListener(EventPriority priority, boolean receiveCancelled, Class<T> eventType, Consumer<T> consumer);
+    <T extends IEvent> void addListener(EventPriority priority, boolean receiveCancelled, Class<T> eventType, Consumer<T> consumer);
 
     /**
      * Add a consumer listener for a {@link GenericEvent} subclass, filtered to only be called for the specified
@@ -147,7 +147,7 @@ public interface IEventBus {
      * @param event The event to dispatch to listeners
      * @return true if the event was {@link Cancelable} cancelled
      */
-    boolean post(Event event);
+    boolean post(IEvent event);
 
     /**
      * Submit the event for dispatch to listeners. The invoke wrapper allows for
@@ -158,12 +158,12 @@ public interface IEventBus {
      * @param wrapper A wrapper function to handle actual dispatch
      * @return true if the event was {@link Cancelable} cancelled
      */
-    boolean post(Event event, IEventBusInvokeDispatcher wrapper);
+    boolean post(IEvent event, IEventBusInvokeDispatcher wrapper);
 
     /**
      * Shuts down this event bus.
      *
-     * No future events will be fired on this event bus, so any call to {@link #post(Event)} will be a no op after this method has been invoked
+     * No future events will be fired on this event bus, so any call to {@link #post(IEvent)} will be a no op after this method has been invoked
      */
     void shutdown();
 

--- a/src/main/java/net/minecraftforge/eventbus/api/IEventBusInvokeDispatcher.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEventBusInvokeDispatcher.java
@@ -5,5 +5,5 @@
 package net.minecraftforge.eventbus.api;
 
 public interface IEventBusInvokeDispatcher {
-    void invoke(IEventListener listener, Event event);
+    void invoke(IEventListener listener, IEvent event);
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/IEventExceptionHandler.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEventExceptionHandler.java
@@ -15,5 +15,5 @@ public interface IEventExceptionHandler {
      * @param index Index for the current listener being fired.
      * @param throwable The throwable being thrown
      */
-    void handleException(IEventBus bus, Event event, IEventListener[] listeners, int index, Throwable throwable);
+    void handleException(IEventBus bus, IEvent event, IEventListener[] listeners, int index, Throwable throwable);
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/IEventListener.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEventListener.java
@@ -9,7 +9,7 @@ package net.minecraftforge.eventbus.api;
  * Event listeners are wrapped with implementations of this interface
  */
 public interface IEventListener {
-    void invoke(Event event);
+    void invoke(IEvent event);
 
     default String listenerName() {
         return getClass().getName();


### PR DESCRIPTION
Adds, and migrates all references, to the IEvent interface to allow creating record based events in the future.

I'm not sure if this was the correct way to do this, but I ran the tests against everything I changed, and added one for the Record events because I wasn't sure it'd work with phases, and they passed. I was going to run the performance tests, and see if there was any notable difference for records, but it was giving a 12 hour ETA so I decided against doing that.