### PR TITLE
Add `IEventBus#fire` to return the posted event object

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
@@ -161,6 +161,22 @@ public interface IEventBus {
     boolean post(Event event, IEventBusInvokeDispatcher wrapper);
 
     /**
+     * Submit the event for dispatch to appropriate listeners and return the (possibly mutated) event
+     *
+     * @param event The event to dispatch to listeners
+     * @return The event object that was dispatched
+     */
+    default <T extends Event> T fire(T event) {
+        post(event);
+        return event;
+    }
+
+    default <T extends Event> T fire(T event, IEventBusInvokeDispatcher wrapper) {
+        post(event, wrapper);
+        return event;
+    }
+
+    /**
      * Shuts down this event bus.
      *
      * No future events will be fired on this event bus, so any call to {@link #post(Event)} will be a no op after this method has been invoked


### PR DESCRIPTION
This PR adds a small helper method that allows for cleaner usage of posted event data.

Before:
```java
var event = new MyEvent();
bus.post(event);
if (event.getResult().isAllowed()) {
    // do thing
}
```

After:
```java
if (bus.fire(new MyEvent()).getResult().isAllowed()) {
    // do thing
}
```