### PR TITLE
Remove reliance on JDK internals in ClassFactory

### DIFF
--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/SubscriberDynamic.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/SubscriberDynamic.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.eventbus.testjar.subscribers;
 
 
+import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
 
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -26,9 +27,13 @@ public class SubscriberDynamic {
     public void onSimpleEvent(EventWithData event) { }
 
     public static class Factory {
-        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>("net.minecraftforge.eventbus.testjar.subscribers.SubscriberDynamic", cls -> {
-            var inst = cls.getConstructor().newInstance();
-            return bus -> bus.register(inst);
-        });
+        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>(
+                SubscriberDynamic.class,
+                MethodHandles.lookup(),
+                cls -> {
+                    var inst = cls.getConstructor().newInstance();
+                    return bus -> bus.register(inst);
+                }
+        );
     }
 }

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/SubscriberLambda.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/SubscriberLambda.java
@@ -5,6 +5,7 @@
 
 package net.minecraftforge.eventbus.testjar.subscribers;
 
+import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
 
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -29,6 +30,10 @@ public class SubscriberLambda {
 
     public static class Factory {
         @SuppressWarnings("unchecked")
-        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>("net.minecraftforge.eventbus.testjar.subscribers.SubscriberLambda", cls -> (Consumer<IEventBus>)cls.getDeclaredField("register").get(null));
+        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>(
+                SubscriberLambda.class,
+                MethodHandles.lookup(),
+                cls -> (Consumer<IEventBus>) cls.getDeclaredField("register").get(null)
+        );
     }
 }

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/SubscriberStatic.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/subscribers/SubscriberStatic.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.eventbus.testjar.subscribers;
 
 
+import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
 
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -26,6 +27,10 @@ public class SubscriberStatic {
     public static void onSimpleEvent(EventWithData event) { }
 
     public static class Factory {
-        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>("net.minecraftforge.eventbus.testjar.subscribers.SubscriberStatic", cls -> bus -> bus.register(cls));
+        public static final ClassFactory<Consumer<IEventBus>> REGISTER = new ClassFactory<>(
+                SubscriberStatic.class,
+                MethodHandles.lookup(),
+                cls -> bus -> bus.register(cls)
+        );
     }
 }


### PR DESCRIPTION
This allows ClassFactory to work on future JDKs without needing adjustments to account for internal changes.