### PR TITLE
Add `startsWith("com.mojang.")` to transform blacklist

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/EventBusEngine.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBusEngine.java
@@ -35,7 +35,7 @@ public final class EventBusEngine implements IEventBusEngine {
     @Override
     public boolean handlesClass(final Type classType) {
         final String name = classType.getClassName();
-        return !(name.startsWith("net.minecraft.") || name.indexOf('.') == -1);
+        return !((name.startsWith("com.mojang.") || name.startsWith("net.minecraft.")) || name.indexOf('.') == -1);
     }
 
     @Override


### PR DESCRIPTION
We already filter out most Vanilla Minecraft classes, but we've been missing some since Blaze3D open sourcing and the like.