### PR TITLE
Simplify listener class checks in posting hot-path

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
@@ -42,11 +42,9 @@ public class ASMEventHandler implements IEventListener {
     @SuppressWarnings("rawtypes")
     @Override
     public void invoke(Event event) {
-        if (handler != null) {
-            if (!event.isCanceled() || subInfo.receiveCanceled()) {
-                if (filter == null || filter == ((IGenericEvent)event).getGenericType())
-                    handler.invoke(event);
-            }
+        if (!event.isCanceled() || subInfo.receiveCanceled()) {
+            if (filter == null || filter == ((IGenericEvent)event).getGenericType())
+                handler.invoke(event);
         }
     }
 

--- a/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
@@ -10,33 +10,32 @@ import java.lang.reflect.*;
 import static org.objectweb.asm.Type.getMethodDescriptor;
 
 public class ASMEventHandler implements IEventListener {
-    private final IEventListenerFactory factory;
     private final IEventListener handler;
     private final SubscribeEvent subInfo;
     private final String readable;
-    private Type filter = null;
+    private final Type filter;
 
     public ASMEventHandler(IEventListenerFactory factory, Object target, Method method, boolean isGeneric) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException, ClassNotFoundException {
-        this.factory = factory;
-        handler = this.factory.create(method, target);
+        handler = factory.create(method, target);
 
         subInfo = method.getAnnotation(SubscribeEvent.class);
         readable = "ASM: " + target + " " + method.getName() + getMethodDescriptor(method);
+        Type filter = null;
         if (isGeneric) {
             Type type = method.getGenericParameterTypes()[0];
             if (type instanceof ParameterizedType) {
                 filter = ((ParameterizedType)type).getActualTypeArguments()[0];
                 if (filter instanceof ParameterizedType) // Unlikely that nested generics will ever be relevant for event filtering, so discard them
                     filter = ((ParameterizedType)filter).getRawType();
-                else if (filter instanceof WildcardType) {
+                else if (filter instanceof WildcardType wfilter) {
                     // If there's a wildcard filter of Object.class, then remove the filter.
-                    final WildcardType wfilter = (WildcardType) filter;
                     if (wfilter.getUpperBounds().length == 1 && wfilter.getUpperBounds()[0] == Object.class && wfilter.getLowerBounds().length == 0) {
                         filter = null;
                     }
                 }
             }
         }
+        this.filter = filter;
     }
 
     @SuppressWarnings("rawtypes")

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -298,7 +298,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
         int index = 0;
         try {
             for (; index < listeners.length; index++) {
-                if (!trackPhases && Objects.equals(listeners[index].getClass(), EventPriority.class)) continue;
+                if (!trackPhases && listeners[index].getClass() == EventPriority.class) continue;
                 wrapper.invoke(listeners[index], event);
             }
         } catch (Throwable throwable) {

--- a/src/main/java/net/minecraftforge/eventbus/ListenerList.java
+++ b/src/main/java/net/minecraftforge/eventbus/ListenerList.java
@@ -203,6 +203,7 @@ public class ListenerList {
         }
 
         public void register(EventPriority priority, IEventListener listener) {
+            if (listener == null) return;
             writeLock.acquireUninterruptibly();
             priorities.get(priority.ordinal()).add(listener);
             writeLock.release();


### PR DESCRIPTION
- Make storing nulls in `ListenerListInst` a no-op
- Skip now-unneeded null checks in `EventBus` and `ASMEventHandler`
- Some trivial cleanup to `ASMEventHandler`'s constructor, make the `filter` field final