### PR TITLE
Fix missing library/modules in eclipse development environments

### DIFF
--- a/eventbus-jmh/build.gradle
+++ b/eventbus-jmh/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'eclipse'
     id 'java-library'
     id 'org.gradlex.extra-java-module-info'
     id 'net.minecraftforge.gradleutils'


### PR DESCRIPTION
Fixes an issue where running `./gradlew eclipse` would not correctly configure the `eventbus-jmh` project for eclipse.

The behavior I was experiencing was that the initial `./gradlew eclipse` task execution configured the `events-jmh` project, but it was missing the `net.minecraftforge.eventbus` module (and referenced libraries).

Subsequent executions of the `./gradlew eclipse` task on the main project failed to configure `events-jmh` at all (task was never executed on the project).

I'm not sure why `./gradlew eclipse` partially configured `eventbus-jmh` on the first run, but did not execute on subsequent runs. However, adding the eclipse plugin to the buildscript causes the project to be properly configured.