### PR TITLE
[6.2.x] Add support for fine-tuned phase tracking

### DIFF
--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/benchmarks/ModLauncherBenchmarks.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/benchmarks/ModLauncherBenchmarks.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.eventbus.testjar.benchmarks;
 
 import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.testjar.events.CancelableEvent;
 import net.minecraftforge.eventbus.testjar.events.EventWithData;
@@ -28,7 +29,7 @@ public final class ModLauncherBenchmarks {
 
     public static final class Post {
         private Post() {}
-        private static final IEventBus EVENT_BUS = BusBuilder.builder().useModLauncher().build();
+        private static final IEventBus EVENT_BUS = BusBuilder.builder().useModLauncher().setPhasesToTrack(EventPriority.MONITOR).build();
 
         public static void setup(int multiplier, Supplier<Consumer<IEventBus>> registrar) {
             for (int i = 0; i < multiplier; i++)

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/benchmarks/NoLoaderBenchmarks.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/benchmarks/NoLoaderBenchmarks.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.eventbus.testjar.benchmarks;
 
 import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.testjar.events.CancelableEvent;
 import net.minecraftforge.eventbus.testjar.events.EventWithData;
@@ -28,7 +29,7 @@ public final class NoLoaderBenchmarks {
 
     public static final class Post {
         private Post() {}
-        private static final IEventBus EVENT_BUS = BusBuilder.builder().build();
+        private static final IEventBus EVENT_BUS = BusBuilder.builder().setPhasesToTrack(EventPriority.MONITOR).build();
 
         public static void setup(int multiplier, Supplier<Consumer<IEventBus>> registrar) {
             for (int i = 0; i < multiplier; i++)

--- a/src/main/java/net/minecraftforge/eventbus/BusBuilderImpl.java
+++ b/src/main/java/net/minecraftforge/eventbus/BusBuilderImpl.java
@@ -4,17 +4,21 @@
  */
 package net.minecraftforge.eventbus;
 
-import net.minecraftforge.eventbus.api.BusBuilder;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.eventbus.api.IEventExceptionHandler;
+import net.minecraftforge.eventbus.api.*;
+
+import java.util.EnumSet;
 
 /**
  * BusBuilder Implementation, public for BusBuilder.builder() only, don't use this directly.
  */
 public final class BusBuilderImpl implements BusBuilder {
+    static final EnumSet<EventPriority> ALL_PHASES = EnumSet.allOf(EventPriority.class);
+    static final EnumSet<EventPriority> NO_PHASES = EnumSet.noneOf(EventPriority.class);
+    private static final EnumSet<EventPriority> MONITOR_ONLY = EnumSet.of(EventPriority.MONITOR);
+
     IEventExceptionHandler exceptionHandler;
     boolean trackPhases = true;
+    EnumSet<EventPriority> phasesToTrack = ALL_PHASES;
     boolean startShutdown = false;
     boolean checkTypesOnDispatch = false;
     Class<?> markerType = Event.class;
@@ -23,7 +27,27 @@ public final class BusBuilderImpl implements BusBuilder {
     @Override
     public BusBuilder setTrackPhases(boolean trackPhases) {
         this.trackPhases = trackPhases;
+        this.phasesToTrack = trackPhases ? ALL_PHASES : NO_PHASES;
         return this;
+    }
+
+    @Override
+    public BusBuilder setPhasesToTrack(EnumSet<EventPriority> phases) {
+        if (phases.isEmpty()) {
+            this.trackPhases = false;
+            this.phasesToTrack = NO_PHASES;
+        } else {
+            this.trackPhases = true;
+            this.phasesToTrack = phases;
+        }
+        return this;
+    }
+
+    @Override
+    public BusBuilder setPhasesToTrack(EventPriority phase) {
+        return phase == EventPriority.MONITOR
+                ? setPhasesToTrack(BusBuilderImpl.MONITOR_ONLY)
+                : setPhasesToTrack(EnumSet.of(phase));
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -25,7 +25,9 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final boolean checkTypesOnDispatchProperty = Boolean.parseBoolean(System.getProperty("eventbus.checkTypesOnDispatch", "false"));
     private static final AtomicInteger maxID = new AtomicInteger(0);
+
     private final boolean trackPhases;
+    final EnumSet<EventPriority> phasesToTrack;
 
     private final ConcurrentHashMap<Object, List<IEventListener>> listeners = new ConcurrentHashMap<>();
     private final int busID = maxID.getAndIncrement();
@@ -41,16 +43,18 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
         ListenerList.resize(busID + 1);
         exceptionHandler = this;
         this.trackPhases = true;
+        this.phasesToTrack = BusBuilderImpl.ALL_PHASES;
         this.baseType = Event.class;
         this.checkTypesOnDispatch = checkTypesOnDispatchProperty;
         this.factory = new ClassLoaderFactory();
     }
 
-    private EventBus(final IEventExceptionHandler handler, boolean trackPhase, boolean startShutdown, Class<?> baseType, boolean checkTypesOnDispatch, IEventListenerFactory factory) {
+    private EventBus(final IEventExceptionHandler handler, boolean trackPhase, EnumSet<EventPriority> phasesToTrack, boolean startShutdown, Class<?> baseType, boolean checkTypesOnDispatch, IEventListenerFactory factory) {
         ListenerList.resize(busID + 1);
         if (handler == null) exceptionHandler = this;
         else exceptionHandler = handler;
         this.trackPhases = trackPhase;
+        this.phasesToTrack = trackPhase ? phasesToTrack : BusBuilderImpl.NO_PHASES;
         this.shutdown = startShutdown;
         this.baseType = baseType;
         this.checkTypesOnDispatch = checkTypesOnDispatch || checkTypesOnDispatchProperty;
@@ -58,7 +62,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     public EventBus(final BusBuilderImpl busBuilder) {
-        this(busBuilder.exceptionHandler, busBuilder.trackPhases, busBuilder.startShutdown,
+        this(busBuilder.exceptionHandler, busBuilder.trackPhases, busBuilder.phasesToTrack, busBuilder.startShutdown,
              busBuilder.markerType, busBuilder.checkTypesOnDispatch,
              busBuilder.modLauncher ? new ModLauncherFactory() : new ClassLoaderFactory());
     }
@@ -268,7 +272,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
 
     private void addToListeners(final Object target, final Class<?> eventType, final IEventListener listener, final EventPriority priority) {
         ListenerList listenerList = EventListenerHelper.getListenerList(eventType);
-        listenerList.register(busID, priority, listener);
+        listenerList.register(busID, this, priority, listener);
         List<IEventListener> others = listeners.computeIfAbsent(target, k -> Collections.synchronizedList(new ArrayList<>()));
         others.add(listener);
     }

--- a/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
@@ -6,6 +6,8 @@ package net.minecraftforge.eventbus.api;
 
 import net.minecraftforge.eventbus.BusBuilderImpl;
 
+import java.util.EnumSet;
+
 /**
  * Build a bus
  */
@@ -16,6 +18,15 @@ public interface BusBuilder {
 
     /* true by default */
     BusBuilder setTrackPhases(boolean trackPhases);
+    default BusBuilder setPhasesToTrack(EnumSet<EventPriority> phases) {
+        throw new UnsupportedOperationException();
+    }
+    default BusBuilder setPhasesToTrack(EventPriority... phases) {
+        return setPhasesToTrack(EnumSet.of(phases[0], phases));
+    }
+    default BusBuilder setPhasesToTrack(EventPriority phase) {
+        return setPhasesToTrack(EnumSet.of(phase));
+    }
     BusBuilder setExceptionHandler(IEventExceptionHandler handler);
     BusBuilder startShutdown();
     BusBuilder checkTypesOnDispatch();


### PR DESCRIPTION
Supersedes #66.

This allows for phase tracking to only apply to the requested phases, rather than an 'all or nothing' like previously.

Will run the benchmarks later when I have time.