### PR TITLE
Add `BusGroup#unregister(EventListener)` for single listeners

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/api/bus/BusGroup.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/bus/BusGroup.java
@@ -89,4 +89,11 @@ public sealed interface BusGroup permits BusGroupImpl {
      *                  {@link #register(MethodHandles.Lookup, Class)} or {@link #register(MethodHandles.Lookup, Object)}
      */
     void unregister(Collection<EventListener> listeners);
+
+    /**
+     * Unregisters the given listener from this BusGroup.
+     * @param listeners The listeners to unregister, contained from the collection obtained from
+     *                  {@link #register(MethodHandles.Lookup, Class)} or {@link #register(MethodHandles.Lookup, Object)}
+     */
+    void unregister(EventListener listeners);
 }

--- a/src/main/java/net/minecraftforge/eventbus/internal/BusGroupImpl.java
+++ b/src/main/java/net/minecraftforge/eventbus/internal/BusGroupImpl.java
@@ -79,8 +79,13 @@ public record BusGroupImpl(
                     "the BusGroup#register method.");
 
         for (var listener : listeners) {
-            getOrCreateEventBus((Class<? extends Event>) listener.eventType()).removeListener(listener);
+            unregister(listener);
         }
+    }
+
+    @Override
+    public void unregister(EventListener listener) {
+        getOrCreateEventBus((Class<? extends Event>) listener.eventType()).removeListener(listener);
     }
 
     //region Internal access only


### PR DESCRIPTION
Allows unregistering an event listener that was registered to a bus group without needing to hunt down the event bus for that bus group.

- Fixes #74.