### PR TITLE
Complete JavaDocs for the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- NOTE: The overview, basic example, and note on nullability are also included in
+     `src/main/java/net/minecraftforge/eventbus/api/package-info.java` -->
+
 # EventBus
 
 A flexible, high-performance, thread-safe subscriber-publisher framework designed with modern Java in mind.
@@ -14,13 +17,13 @@ First, add the Forge Maven repository and the EventBus dependency to your projec
 ```gradle
 repositories {
     maven {
-        name = "Forge"
-        url = "https://maven.minecraftforge.net"
+        name = 'Forge'
+        url = 'https://maven.minecraftforge.net'
     }
 }
 
 dependencies {
-    implementation "net.minecraftforge:eventbus:<version>"
+    implementation 'net.minecraftforge:eventbus:<version>'
 }
 ```
 
@@ -47,11 +50,11 @@ Browse the `net.minecraftforge.eventbus.api` package and read the Javadocs for m
 examples, check out Forge's extensive use of EventBus [here][Forge usages].
 
 ## Nullability
-The entirety of EventBus' API is `@NullMarked` and compliant with the [jSpecify specification](https://jspecify.dev/) -
-this means that everything is non-null by default unless otherwise specified.
+The entirety of EventBus' API is `@NullMarked` and compliant with the [jSpecify specification](https://jspecify.dev/).
+This means that everything is non-null by default unless otherwise specified.
 
-Attempting to pass a `null` value to a method param that isn't explicitly marked as `@Nullable` is an unsupported
-operation and won't be considered a breaking change if a future version throws an exception in such cases when it didn't
+Attempting to pass a `null` value to a method param that isn't explicitly marked as `@Nullable` is an *unsupported
+operation* and won't be considered a breaking change if a future version throws an exception in such cases when it didn't
 before.
 
 ## Contributing

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ java {
     toolchain.languageVersion = JavaLanguageVersion.of(21)
     modularity.inferModulePath = true
     withSourcesJar()
+    withJavadocJar()
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,13 @@ changelog {
     from '1.0.0'
 }
 
+tasks.withType(Javadoc).configureEach {
+    options { StandardJavadocDocletOptions options ->
+        options.windowTitle = 'EventBus ' + project.version
+        options.tags 'apiNote:a:API Note:', 'implNote:a:Implementation Note:', 'implSpec:a:Implementation Specification:'
+    }
+}
+
 tasks.withType(JavaCompile).configureEach {
     // Set up compile-time enforcement of the jSpecify spec via ErrorProne and NullAway
     options.errorprone { ErrorProneOptions errorProne ->

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ repositories {
 
 dependencies {
     api libs.jspecify.annotations
+    compileOnly libs.jetbrains.annotations
     errorprone libs.errorprone.core
     errorprone libs.nullaway
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'org.gradlex.extra-java-module-info' version '1.11'
     id 'net.minecraftforge.gradleutils' version '2.4.13'
     id 'net.minecraftforge.licenser' version '1.1.1'
+    alias libs.plugins.javadoc.links
 
     // Enforce jSpecify annotations at compile-time
     id 'net.ltgt.errorprone' version '4.1.0'

--- a/eventbus-jmh/build.gradle
+++ b/eventbus-jmh/build.gradle
@@ -36,6 +36,10 @@ extraJavaModuleInfo {
     automaticModule('net.sf.jopt-simple:jopt-simple', 'jopt.simple')
 }
 
+tasks.named('javadoc', Javadoc) {
+    enabled = false
+}
+
 tasks.register('aggregateJmh', AggregateJmh) {
     if (rootProject.file('jmh_data_input.json').exists())
         inputData = rootProject.file('jmh_data_input.json')

--- a/eventbus-test-jar/build.gradle
+++ b/eventbus-test-jar/build.gradle
@@ -33,6 +33,10 @@ license {
     newLine = false
 }
 
+tasks.named('javadoc', Javadoc) {
+    enabled = false
+}
+
 // Hack eclipse into knowing that the gradle deps are modules
 eclipse.classpath {
     containers 'org.eclipse.buildship.core.gradleclasspathcontainer'

--- a/eventbus-test/build.gradle
+++ b/eventbus-test/build.gradle
@@ -33,6 +33,10 @@ extraJavaModuleInfo {
     failOnMissingModuleInfo = false
 }
 
+tasks.named('javadoc', Javadoc) {
+    enabled = false
+}
+
 tasks.named('test', Test) {
     useJUnitPlatform()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,8 @@ plugins {
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
+            plugin 'javadoc-links', 'io.freefair.javadoc-links' version '8.13.1'
+
             // https://mvnrepository.com/artifact/org.jspecify/jspecify
             library('jspecify-annotations', 'org.jspecify', 'jspecify') version '1.0.0'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
 
             // https://mvnrepository.com/artifact/org.jspecify/jspecify
             library('jspecify-annotations', 'org.jspecify', 'jspecify') version '1.0.0'
+            library 'jetbrains-annotations', 'org.jetbrains', 'annotations' version '26.0.2'
 
             // https://mvnrepository.com/artifact/com.google.errorprone/error_prone_core
             library('errorprone-core', 'com.google.errorprone', 'error_prone_core') version '2.36.0'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -48,8 +48,9 @@ import org.jspecify.annotations.NullMarked;
  */
 @NullMarked
 module net.minecraftforge.eventbus {
-    requires java.logging;
-    requires org.jspecify;
+    requires java.logging;                     // Logging
+    requires org.jspecify;                     // Nullability
+    requires static org.jetbrains.annotations; // Other Static Analysis
 
     exports net.minecraftforge.eventbus.api.bus;
     exports net.minecraftforge.eventbus.api.event;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -4,6 +4,48 @@
  */
 import org.jspecify.annotations.NullMarked;
 
+/**
+ * EventBus is a flexible, high-performance, thread-safe subscriber-publisher framework designed with modern Java in
+ * mind.
+ *
+ * <h2>Overview</h2>
+ * <p>The core functionality of EventBus is to provide a simple and efficient way to handle
+ * {@linkplain net.minecraftforge.eventbus.api.event events} in a decoupled manner.</p>
+ * <p>Each event may have one or more {@linkplain net.minecraftforge.eventbus.api.bus.EventBus buses} associated with
+ * it, which are responsible for managing {@linkplain net.minecraftforge.eventbus.api.listener.EventListener listeners}
+ * and dispatching instances of the event object to them. To maximise performance, the underlying implementation is
+ * tailored on the fly based on the event's type,
+ * {@linkplain net.minecraftforge.eventbus.api.event.characteristic characteristics}, inheritance chain and the number
+ * and type of listeners registered to the bus.</p>
+ *
+ * <h2>Example</h2>
+ * <p>Here is a basic usage example of EventBus in action:</p>
+ * {@snippet :
+ * import net.minecraftforge.eventbus.api.event.RecordEvent;
+ * import net.minecraftforge.eventbus.api.bus.EventBus;
+ *
+ * // Define an event and a bus for it
+ * record PlayerLoggedInEvent(String username) implements RecordEvent {
+ *     public static final EventBus<PlayerLoggedInEvent> BUS = EventBus.create(PlayerLoggedInEvent.class);
+ * }
+ *
+ * // Register an event listener
+ * PlayerLoggedInEvent.BUS.addListener(event -> System.out.println("Player logged in: " + event.username()));
+ *
+ * // Post an event to the registered listeners
+ * PlayerLoggedInEvent.BUS.post(new PlayerLoggedInEvent("Paint_Ninja"));
+ *}
+ * <p>There are several more example usages within the JavaDocs of the different packages and classes in this API
+ * module. These examples are non-exhaustive, but provide a good basis on which to build your usage of EventBus.</p>
+ *
+ * <h2>Nullability</h2>
+ * <p>The entirety of EventBus' API is {@link org.jspecify.annotations.NullMarked @NullMarked} and compliant with the
+ * <a href="https://jspecify.dev/">jSpecify specification</a>. This means that everything is
+ * {@linkplain org.jspecify.annotations.NonNull non-null} by default unless otherwise specified.</p>
+ * <p>Attempting to pass a {@code null} value to a method param that isn't explicitly marked as
+ * {@link org.jspecify.annotations.Nullable @Nullable} is an <i>unsupported operation</i> and won't be considered a
+ * breaking change if a future version throws an exception in such cases when it didn't before.</p>
+ */
 @NullMarked
 module net.minecraftforge.eventbus {
     requires java.logging;

--- a/src/main/java/net/minecraftforge/eventbus/api/bus/BusGroup.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/bus/BusGroup.java
@@ -4,89 +4,191 @@
  */
 package net.minecraftforge.eventbus.api.bus;
 
-import net.minecraftforge.eventbus.internal.Event;
 import net.minecraftforge.eventbus.api.listener.EventListener;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.eventbus.internal.BusGroupImpl;
+import net.minecraftforge.eventbus.internal.Event;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 
 /**
- * A collection of {@link EventBus} instances that are grouped together for easier management.
+ * A bus group is a collection of {@link EventBus} instances that are grouped together for easier management.
+ * <p>Using a bus group allows consumers to manage all of their related event buses without needing to manually manage
+ * each one.</p>
+ *
+ * <h2>Example</h2>
+ * <p>Here is a small example showing the creation and disposal of a bus group.</p>
+ * {@snippet :
+ * import net.minecraftforge.eventbus.api.bus.BusGroup;
+ * import net.minecraftforge.eventbus.api.bus.EventBus;
+ * import net.minecraftforge.eventbus.api.event.RecordEvent;
+ * import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
+ *
+ * import java.lang.invoke.MethodHandles;
+ *
+ * public class MyClass {
+ *     public static final BusGroup BUS_GROUP = BusGroup.create("MyProject", RecordEvent.class);
+ *
+ *     public record MyEvent(String message) implements RecordEvent {
+ *         public static final EventBus<MyEvent> BUS = EventBus.create(BUS_GROUP, MyEvent.class);
+ *     }
+ *
+ *     @SubscribeEvent
+ *     private static void onMyEvent(MyEvent event) {
+ *         System.out.println("Received event: " + event.message());
+ *     }
+ *
+ *     // if we only have one listener in our class, EventBus will throw an exception saying you should use BusGroup#addListener instead
+ *     @SubscribeEvent
+ *     private static void alsoOnMyEvent(MyEvent event) {
+ *         System.out.println("Double checking, received event: " + event.message());
+ *     }
+ *
+ *     // begin program!
+ *     public static void run() {
+ *         // the bus group is already started! no need to call startup() on it.
+ *
+ *         // MethodHandles.lookup() gives EventBus the ability to get method references
+ *         // for all the @SubscribeEvent methods in this class.
+ *         BUS_GROUP.register(MethodHandles.lookup(), MyClass.class);
+ *     }
+ *
+ *     // close program!
+ *     public static void shutdown() {
+ *         // dispose will shutdown and then dispose this bus group
+ *         // consider it "freed memory" that should not be reused
+ *         BUS_GROUP.dispose();
+ *     }
+ * }
+ *}
  */
 public sealed interface BusGroup permits BusGroupImpl {
+    /**
+     * The default bus group, which is used when an {@linkplain EventBus event bus} is created without specifying a
+     * group.
+     *
+     * @apiNote If you require tight controls over your event buses, you should create your own bus group instead. This
+     * bus group can be used and mutated by other consumers within the same environment.
+     * @see EventBus#create(Class)
+     */
     BusGroup DEFAULT = create("default");
 
+    /**
+     * Creates a new bus group with the given name.
+     * <p>The name for this bus group <i>must be unique.</i> An attempt to create a bus group with a name that is
+     * already in use will result in an {@link IllegalArgumentException}. If you must create a new bus group with a name
+     * that is in use, the relevant bus group must be {@linkplain #dispose() disposed}.</p>
+     *
+     * @param name The name
+     * @return The new bus group
+     * @throws IllegalArgumentException If the name is already in use by another bus group
+     * @apiNote To enforce a base type with your bus group, use {@linkplain #create(String, Class)}.
+     */
     static BusGroup create(String name) {
         return new BusGroupImpl(name, Event.class);
     }
 
+    /**
+     * Creates a new bus group with the given name.
+     * <p>The given base type will enforce that all {@linkplain EventBus event buses} created within this group inherit
+     * it.</p>
+     * <p>The name for this bus group <i>must be unique.</i> An attempt to create a bus group with a name that is
+     * already in use will result in an {@link IllegalArgumentException}. If you must create a new bus group with a name
+     * that is in use, the relevant bus group must be {@linkplain #dispose() disposed}.</p>
+     *
+     * @param name The name
+     * @return The new bus group
+     * @throws IllegalArgumentException If the name is already in use by another bus group
+     */
     static BusGroup create(String name, Class<?> baseType) {
         return new BusGroupImpl(name, baseType);
     }
 
     /**
      * The unique name of this BusGroup.
+     * <p>The uniqueness of this name is enforced when the bus group is {@linkplain #create(String) created}.</p>
      */
     String name();
 
     /**
-     * Starts up all EventBus instances associated with this BusGroup, allowing events to be posted again after a
+     * Starts up all EventBus instances associated with this bus group, allowing events to be posted again after a
      * previous call to {@link #shutdown()}.
+     * <p>Calling this method without having previously called {@link #shutdown()} will have no effect.</p>
      */
     void startup();
 
     /**
-     * Shuts down all EventBus instances associated with this BusGroup, preventing any further events from being posted
+     * Shuts down all EventBus instances associated with this bus group, preventing any further events from being posted
      * until {@link #startup()} is called.
+     * <p>Calling this method without having previously called {@link #startup()} will have no effect.</p>
+     *
+     * @apiNote If you need to destroy this bus group and free up the resources it uses, use {@link #dispose()}.
      */
     void shutdown();
 
     /**
-     * Shuts down all EventBus instances associated with this BusGroup, unregisters all listeners and frees resources
-     * no longer needed.
-     * <p>Warning: This is a destructive operation - this BusGroup should not be used again after calling this method.</p>
+     * {@linkplain #shutdown() Shuts down} all EventBus instances associated with this bus group,
+     * {@linkplain #unregister(Collection) unregisters} all listeners and frees resources no longer needed.
+     * <p><strong>This will effectively destroy this bus group.</strong> It should not be used again after calling this
+     * method.</p>
+     *
+     * @apiNote If you plan on using this bus group again, use {@link #shutdown()} instead.
      */
     void dispose();
 
     /**
-     * Experimental feature - may be removed, renamed or otherwise changed without notice.
-     * <p>Trims the backing lists of all EventBus instances associated with this BusGroup to free up resources.</p>
-     * <p>Warning: This is only intended to be called <b>once</b> after all listeners are registered - calling this
+     * Trims the backing lists of all EventBus instances associated with this BusGroup to free up resources.
+     * <p>This is only intended to be called <strong>once</strong> after all listeners are registered. Calling this
      * repeatedly may hurt performance.</p>
+     *
+     * @apiNote <strong>This is an experimental feature!</strong> It may be removed, renamed or otherwise changed
+     * without notice.
      */
     void trim();
 
     /**
-     * Registers all static methods annotated with {@link SubscribeEvent} in the given class.
+     * Registers all <i>static</i> methods annotated with {@link SubscribeEvent} in the given class.
+     * <p>This is done by getting method references for those methods using the given
+     * {@linkplain MethodHandles.Lookup method handles lookup}. This lookup <strong>must be acquiored from
+     * {@link MethodHandles#lookup()}.</strong> Using {@link MethodHandles#publicLookup()} is unsupported because it
+     * doesn't work with {@link java.lang.invoke.LambdaMetafactory} as it could allow for access to private fields
+     * through inner class generation.</p>
      *
-     * @param callerLookup {@code MethodHandles.lookup()} from the class containing listeners
+     * @param callerLookup                    {@link MethodHandles#lookup()} from the class containing listeners
      * @param utilityClassWithStaticListeners the class containing the static listeners
      * @return A collection of the registered listeners, which can be used to optionally unregister them later
-     *
      * @apiNote This method only registers static listeners.
-     *          <p>If you want to register both instance and static methods, use
-     *          {@link BusGroup#register(MethodHandles.Lookup, Object)} instead.</p>
+     * <p>If you want to register both instance and static methods, use
+     * {@link BusGroup#register(MethodHandles.Lookup, Object)} instead.</p>
      */
     Collection<EventListener> register(MethodHandles.Lookup callerLookup, Class<?> utilityClassWithStaticListeners);
 
     /**
      * Registers all methods annotated with {@link SubscribeEvent} in the given object.
+     * <p>Both the static <i>and</i> instance methods for the given object are registered. Keep in mind that, unlike
+     * with {@link #register(MethodHandles.Lookup, Class)}, you will need to register each object instance of the class
+     * using this method.</p>
+     * <p>This is done by getting method references for those methods using the given
+     * {@linkplain MethodHandles.Lookup method handles lookup}. This lookup <strong>must be acquiored from
+     * {@link MethodHandles#lookup()}.</strong> Using {@link MethodHandles#publicLookup()} is unsupported because it
+     * doesn't work with {@link java.lang.invoke.LambdaMetafactory} as it could allow for access to private fields
+     * through inner class generation.</p>
      *
      * @param callerLookup {@code MethodHandles.lookup()} from the class containing the listeners
-     * @param listener the object containing the static and/or instance listeners
+     * @param listener     the object containing the static and/or instance listeners
      * @return A collection of the registered listeners, which can be used to optionally unregister them later
-     *
      * @apiNote If you know all the listeners are static methods, use
-     *          {@link BusGroup#register(MethodHandles.Lookup, Class)} instead for better registration performance.
+     * {@link BusGroup#register(MethodHandles.Lookup, Class)} instead for better registration performance.
      */
     Collection<EventListener> register(MethodHandles.Lookup callerLookup, Object listener);
 
     /**
-     * Unregisters the given listeners from this BusGroup.
+     * Unregisters the given listeners from this bus group.
+     *
      * @param listeners A collection of listeners to unregister, obtained from
-     *                  {@link #register(MethodHandles.Lookup, Class)} or {@link #register(MethodHandles.Lookup, Object)}
+     *                  {@link #register(MethodHandles.Lookup, Class)} or
+     *                  {@link #register(MethodHandles.Lookup, Object)}
      */
     void unregister(Collection<EventListener> listeners);
 }

--- a/src/main/java/net/minecraftforge/eventbus/api/bus/BusGroup.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/bus/BusGroup.java
@@ -8,6 +8,8 @@ import net.minecraftforge.eventbus.api.listener.EventListener;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.eventbus.internal.BusGroupImpl;
 import net.minecraftforge.eventbus.internal.Event;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
@@ -109,6 +111,7 @@ public sealed interface BusGroup permits BusGroupImpl {
      * The unique name of this BusGroup.
      * <p>The uniqueness of this name is enforced when the bus group is {@linkplain #create(String) created}.</p>
      */
+    @Contract(pure = true)
     String name();
 
     /**
@@ -145,6 +148,7 @@ public sealed interface BusGroup permits BusGroupImpl {
      * @apiNote <strong>This is an experimental feature!</strong> It may be removed, renamed or otherwise changed
      * without notice.
      */
+    @ApiStatus.Experimental
     void trim();
 
     /**

--- a/src/main/java/net/minecraftforge/eventbus/api/bus/CancellableEventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/bus/CancellableEventBus.java
@@ -11,6 +11,7 @@ import net.minecraftforge.eventbus.api.listener.ObjBooleanBiConsumer;
 import net.minecraftforge.eventbus.api.listener.Priority;
 import net.minecraftforge.eventbus.internal.BusGroupImpl;
 import net.minecraftforge.eventbus.internal.CancellableEventBusImpl;
+import org.jetbrains.annotations.Contract;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -66,6 +67,10 @@ public sealed interface CancellableEventBus<T extends Event & Cancellable>
      * @return A reference that can be used to remove this listener later with {@link #removeListener(EventListener)}.
      */
     EventListener addListener(ObjBooleanBiConsumer<T> listener);
+
+    @Override
+    @Contract("_ -> _")
+    boolean post(T event);
 
     /**
      * Creates a new CancellableEventBus for the given event type on the default {@link BusGroup}.

--- a/src/main/java/net/minecraftforge/eventbus/api/bus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/bus/EventBus.java
@@ -4,75 +4,143 @@
  */
 package net.minecraftforge.eventbus.api.bus;
 
-import net.minecraftforge.eventbus.internal.Event;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.eventbus.api.listener.EventListener;
 import net.minecraftforge.eventbus.api.listener.Priority;
 import net.minecraftforge.eventbus.internal.AbstractEventBusImpl;
 import net.minecraftforge.eventbus.internal.BusGroupImpl;
+import net.minecraftforge.eventbus.internal.Event;
 import net.minecraftforge.eventbus.internal.EventBusImpl;
 
 import java.util.function.Consumer;
 
+/**
+ * An event bus is a host of listeners for a specific event.
+ * <p>It can be thought of much like an actual bus. A bus has passengers that are all headed for the same destination,
+ * or at least are on the same route.</p>
+ *
+ * <h2>Usage</h2>
+ * <p>The key idea to understand about an event bus is that is designed to be used with a specific event tied to a
+ * specific {@linkplain BusGroup bus group}. While not all listeners on the event bus may behave the same, they are all
+ * listening for the same event.</p>
+ * <p>Listeners can have different characteristics based on how it is registered (this may be subject to the event's
+ * {@linkplain net.minecraftforge.eventbus.api.event.characteristic characteristics}). They are registered through
+ * {@link #addListener(Consumer)} or one of its sister methods. Each registering method contains additional details on
+ * how the registered listener behaves.</p>
+ *
+ * <h2>Example</h2>
+ * <p>Here is a small example showing the simple registration of two event listeners with different priorities.</p>
+ * {@snippet :
+ * import net.minecraftforge.eventbus.api.bus.EventBus;
+ * import net.minecraftforge.eventbus.api.event.MutableEvent;
+ * import net.minecraftforge.eventbus.api.listener.Priority;
+ *
+ * public class MyCustomEvent extends MutableEvent {
+ *     protected static final String HELLO = "Hello, world!";
+ *
+ *     public static final EventBus<MyCustomEvent> BUS = EventBus.create(MyCustomEvent.class);
+ *
+ *     private static void onMyCustomEvent(MyCustomEvent event) {
+ *         System.out.println("Received custom event: " + event);
+ *     }
+ *
+ *     private static void alsoOnMyCustomEvent(MyCustomEvent event) {
+ *         System.out.println("Received custom event (but later!): " + event);
+ *     }
+ *
+ *     public static void run() {
+ *         BUS.addListener(MyCustomEvent::onMyCustomEvent);
+ *         BUS.addListener(Priority.LOW, MyCustomEvent::alsoOnMyCustomEvent);
+ *     }
+ * }
+ *}
+ *
+ * <h2>Cancellability</h2>
+ * <p>Events have the ability to be {@linkplain Cancellable cancellable}. If you need to use a cancellable event, use
+ * {@link CancellableEventBus} instead, which include special handling for posting cancellable events and recieving the
+ * cancellation state. As discussed in the documentation for the cancellable characteristic, the cancellation state is
+ * <i>not attached</i> to the event instance.</p>
+ *
+ * @param <T> The event type this bus is for
+ */
 public sealed interface EventBus<T extends Event> permits CancellableEventBus, AbstractEventBusImpl, EventBusImpl {
     /**
      * Adds a listener to this EventBus with the default priority of {@link Priority#NORMAL}.
+     *
      * @param listener The listener to add
      * @return A reference that can be used to remove this listener later with {@link #removeListener(EventListener)}
      */
     EventListener addListener(Consumer<T> listener);
 
     /**
-     * Adds a listener to this EventBus with the given priority.
-     * @param priority The priority of this listener. Higher numbers are called first.
+     * Adds a listener to this EventBus with the given {@linkplain Priority priority}.
+     *
+     * @param priority The priority of this listener
      * @param listener The listener to add
      * @return A reference that can be used to remove this listener later with {@link #removeListener(EventListener)}
-     * @see Priority For common priority values
+     * @see Priority
      */
     EventListener addListener(byte priority, Consumer<T> listener);
 
     /**
      * Re-adds a listener to this EventBus that was previously removed with {@link #removeListener(EventListener)}.
-     * @param listener The exact same reference returned by an {@code addListener} method
-     * @return The same reference that was passed in
+     *
+     * @param listener The event listener returned immediately after it was initially added
+     * @return The listener that was re-added
+     * @apiNote Using this over re-adding the listener with {@link #addListener(Consumer)} is recommended for
+     * performance, as it removes the need to create another {@link EventListener} state.
      */
     EventListener addListener(EventListener listener);
 
     /**
-     * Removes a listener from this EventBus that was previously added with one of the {@code addListener} methods.
-     * @param listener The exact same reference returned by an {@code addListener} method
+     * Removes a listener from this EventBus that was previously added with {@link #addListener(Consumer)} or one of its
+     * sisters.
+     *
+     * @param listener The event listener returned immediately after it was initially added
      */
     void removeListener(EventListener listener);
 
     /**
+     * Posts the given event to all listeners registered to this bus.
+     *
      * @param event The instance of this event to post to listeners
-     * @return {@code true} if the event implements {@link Cancellable} and the event was cancelled
-     *         by a listener
+     * @return {@code false}
+     * @apiNote This bus will <strong>always return {@code false}</strong> unless it is a
+     * {@linkplain CancellableEventBus cancellable event bus}.
+     * @see CancellableEventBus#post(Event)
      */
     boolean post(T event);
 
     /**
+     * Fires the given event to all listeners registered to this bus.
+     * <p>After posting, the event itself is returned from this method. <i>It may be mutated.</i></p>
+     *
      * @param event The instance of this event to fire to listeners
-     * @return The possibly mutated event instance after all applicable listeners have been called
+     * @return The event after being posted
      */
     T fire(T event);
 
     /**
-     * If making a new event instance is expensive, you can check against this method to avoid creating a new instance
-     * unnecessarily.
-     * @apiNote You only need to check this if event creation is expensive. If it's cheap, just call {@link #post(Event)}
-     *          or {@link #fire(Event)} directly and let the JIT handle it.
-     * @return {@code true} if there are any listeners registered to this EventBus.
+     * Checks if this event bus has any listeners registered to it.
+     * <p>If making a new event instance is expensive, you can check against this method to avoid creating a new
+     * instance unnecessarily.</p>
+     *
+     * @return {@code true} if there are any listeners registered
+     * @apiNote If event creation is cheap, you should instead call {@link #post(Event)} or {@link #fire(Event)}
+     * directly and let the JIT handle the side effects.
      */
     boolean hasListeners();
 
     /**
-     * Creates a new EventBus for the given event type on the default {@link BusGroup}.
-     * <p>
-     *     <b>Important:</b> The returned EventBus MUST be stored in a {@code static final} field - failing to do so
-     *     will severely hurt performance
-     * </p>
-     * @apiNote There can only be one EventBus instance per event type per BusGroup.
+     * Creates a new EventBus for the given event type on the {@linkplain BusGroup#DEFAULT default bus group}.
+     * <p>The returned EventBus <strong>must be stored in a {@code static final} field!</strong> Failing to do so will
+     * severely hinder performance.</p>
+     * <p>Additionally, there can only be one event bus instance per event type per bus group. If an event bus already
+     * exists for the given type, it will be returned instead.</p>
+     *
+     * @param eventType The event type for the bus
+     * @param <E>       The type of event this bus is for
+     * @return The newly-created event bus
      */
     @SuppressWarnings("ClassEscapesDefinedScope") // E can be a subtype of Event which is publicly accessible
     static <E extends Event> EventBus<E> create(Class<E> eventType) {
@@ -80,12 +148,16 @@ public sealed interface EventBus<T extends Event> permits CancellableEventBus, A
     }
 
     /**
-     * Creates a new EventBus for the given event type on the given {@link BusGroup}.
-     * <p>
-     *     <b>Important:</b> The returned EventBus MUST be stored in a {@code static final} field - failing to do so
-     *     will severely hurt performance
-     * </p>
-     * @apiNote There can only be one EventBus instance per event type per BusGroup.
+     * Creates a new event bus for the given event type on the given {@linkplain BusGroup bus group}.
+     * <p>The returned event bus <strong>must be stored in a {@code static final} field!</strong> Failing to do so will
+     * severely hinder performance.</p>
+     * <p>Additionally, there can only be one event bus instance per event type per bus group. If an event bus already
+     * exists for the given type, it will be returned instead.</p>
+     *
+     * @param busGroup  The bus group to create the event bus on
+     * @param eventType The event type for the bus
+     * @param <E>       The type of event this bus is for
+     * @return The newly-created event bus
      */
     @SuppressWarnings("ClassEscapesDefinedScope") // E can be a subtype of Event which is publicly accessible
     static <E extends Event> EventBus<E> create(BusGroup busGroup, Class<E> eventType) {

--- a/src/main/java/net/minecraftforge/eventbus/api/bus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/bus/EventBus.java
@@ -11,6 +11,7 @@ import net.minecraftforge.eventbus.internal.AbstractEventBusImpl;
 import net.minecraftforge.eventbus.internal.BusGroupImpl;
 import net.minecraftforge.eventbus.internal.Event;
 import net.minecraftforge.eventbus.internal.EventBusImpl;
+import org.jetbrains.annotations.Contract;
 
 import java.util.function.Consumer;
 
@@ -90,6 +91,7 @@ public sealed interface EventBus<T extends Event> permits CancellableEventBus, A
      * @apiNote Using this over re-adding the listener with {@link #addListener(Consumer)} is recommended for
      * performance, as it removes the need to create another {@link EventListener} state.
      */
+    @Contract("_ -> param1")
     EventListener addListener(EventListener listener);
 
     /**
@@ -109,6 +111,7 @@ public sealed interface EventBus<T extends Event> permits CancellableEventBus, A
      * {@linkplain CancellableEventBus cancellable event bus}.
      * @see CancellableEventBus#post(Event)
      */
+    @Contract(value = "_ -> false")
     boolean post(T event);
 
     /**
@@ -118,6 +121,7 @@ public sealed interface EventBus<T extends Event> permits CancellableEventBus, A
      * @param event The instance of this event to fire to listeners
      * @return The event after being posted
      */
+    @Contract(value = "_ -> param1")
     T fire(T event);
 
     /**

--- a/src/main/java/net/minecraftforge/eventbus/api/event/characteristic/MonitorAware.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/event/characteristic/MonitorAware.java
@@ -6,14 +6,21 @@ package net.minecraftforge.eventbus.api.event.characteristic;
 
 import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.internal.MutableEventInternals;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 
 /**
- * Experimental feature - may be removed, renamed or otherwise changed without notice.
- * <p>Events that are {@link MonitorAware} can provide stronger immutability guarantees to monitor listeners by
- * returning unmodifiable views or throwing exceptions on mutation attempts when monitoring.</p>
+ * Events that are {@link MonitorAware} can provide stronger immutability guarantees to monitor listeners by returning
+ * unmodifiable views or throwing exceptions on mutation attempts when monitoring.
  * <p>Only supported for {@link MutableEvent} at this time.</p>
+ *
+ * @apiNote <strong>This is an experimental feature!</strong> It may be removed, renamed or otherwise changed without
+ * notice.
  */
+@ApiStatus.Experimental
 public non-sealed interface MonitorAware extends EventCharacteristic {
+    @Contract(pure = true)
+    @ApiStatus.NonExtendable
     default boolean isMonitoring() {
         assert this instanceof MutableEvent; // note: MutableEvent extends MutableEventInternals
         return ((MutableEventInternals) this).isMonitoring;

--- a/src/main/java/net/minecraftforge/eventbus/api/event/characteristic/SelfPosting.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/event/characteristic/SelfPosting.java
@@ -6,12 +6,14 @@ package net.minecraftforge.eventbus.api.event.characteristic;
 
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.internal.Event;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 
 /**
- * Experimental feature - may be removed, renamed or otherwise changed without notice.
- * <p>{@link SelfPosting} events are associated with a default {@link EventBus} in order to offer some convenience
- * instance methods.</p>
- * <u>Example</u>
+ * Self-posting events are associated with a default {@link EventBus} in order to offer some convenience instance
+ * methods.
+ *
+ * <h2>Example</h2>
  * {@snippet :
  * import net.minecraftforge.eventbus.api.event.RecordEvent;
  *
@@ -31,7 +33,11 @@ import net.minecraftforge.eventbus.internal.Event;
  * // instead of this
  * ExampleEvent.BUS.post(new ExampleEvent());
  *}
+ *
+ * @apiNote <strong>This is an experimental feature!</strong> It may be removed, renamed or otherwise changed without
+ * notice.
  */
+@ApiStatus.Experimental
 public non-sealed interface SelfPosting<T extends Event> extends EventCharacteristic {
     /**
      * @implSpec This should directly return a {@code static final} field without additional logic or processing.
@@ -49,6 +55,7 @@ public non-sealed interface SelfPosting<T extends Event> extends EventCharacteri
     /**
      * @see EventBus#fire(Event)
      */
+    @Contract(value = "-> this")
     @SuppressWarnings("unchecked")
     default T fire() {
         return getDefaultBus().fire((T) this);

--- a/src/main/java/net/minecraftforge/eventbus/api/listener/EventListener.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/listener/EventListener.java
@@ -8,6 +8,7 @@ import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.internal.Event;
 import net.minecraftforge.eventbus.internal.EventListenerImpl;
+import org.jetbrains.annotations.Contract;
 
 import java.util.function.Consumer;
 
@@ -19,17 +20,20 @@ import java.util.function.Consumer;
  * various conversion operations to different lambda types.</p>
  */
 public sealed interface EventListener permits EventListenerImpl {
+    @Contract(pure = true)
     @SuppressWarnings("ClassEscapesDefinedScope") // ? can be a subtype of Event which is publicly accessible
     Class<? extends Event> eventType();
 
     /**
      * @see Priority
      */
+    @Contract(pure = true)
     byte priority();
 
     /**
      * @see CancellableEventBus#addListener(boolean, Consumer)
      */
+    @Contract(pure = true)
     default boolean alwaysCancelling() {
         return false;
     }

--- a/src/main/java/net/minecraftforge/eventbus/internal/MutableEventInternals.java
+++ b/src/main/java/net/minecraftforge/eventbus/internal/MutableEventInternals.java
@@ -8,8 +8,6 @@ import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.MonitorAware;
 
 public sealed abstract class MutableEventInternals permits MutableEvent {
-    /**
-     * @see MonitorAware
-     */
+    /** @see MonitorAware#isMonitoring() */
     public transient boolean isMonitoring;
 }


### PR DESCRIPTION
This PR adds complete JavaDocs to EventBus 7. These JavaDocs include explanations for type usage, use cases for the various characteristics, and *non-exhaustive* example snippets.

Additionally, this PR adds JetBrains annotations. The annotations in question are not `@Nullable` or `@NotNull`, but rather documentation annotations such as the ones in `ApiStatus` and IDE support annotations such as `@Contract`.

The JavaDocs have been written to be best presented within a JavaDocs website, which would theoretically be on the MinecraftForge domain (i.e. `javadocs.minecraftforge.net`), but they are also included as usual in the `javadoc.jar` file built by the project.