### PR TITLE
Enhance alwaysCancelling listener awareness in invoker optimisation strategy

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/internal/Constants.java
+++ b/src/main/java/net/minecraftforge/eventbus/internal/Constants.java
@@ -19,6 +19,7 @@ final class Constants {
 
     static final Consumer<Event> NO_OP_CONSUMER = event -> {};
     static final Predicate<Event> NO_OP_PREDICATE = event -> false;
+    static final Predicate<Event> ALWAYS_TRUE_PREDICATE = event -> true;
 
     static final MethodHandle MH_NULL_CONSUMER = MethodHandles.constant(Consumer.class, null);
     static final MethodHandle MH_NO_OP_CONSUMER = MethodHandles.constant(Consumer.class, NO_OP_CONSUMER);
@@ -60,8 +61,8 @@ final class Constants {
     }
 
     @SuppressWarnings("unchecked")
-    static <T> Predicate<T> getNoOpPredicate() {
-        return (Predicate<T>) NO_OP_PREDICATE;
+    static <T> Predicate<T> getNoOpPredicate(boolean alwaysCancelling) {
+        return (Predicate<T>) (alwaysCancelling ? ALWAYS_TRUE_PREDICATE : NO_OP_PREDICATE);
     }
 
     static boolean isSelfDestructing(int characteristics) {


### PR DESCRIPTION
If the event is cancellable but all listeners are consumers, the invoker optimisation strategy would previously bail out to using the wrapped predicates if alwaysCancelling listeners were present. The listener elimination optimisation would still apply, but redundant wrapping remained.

Now, alwaysCancelling listeners are properly accounted for in this case, combining the benefits of eliminating non-monitoring listeners after them with also unwrapping to branchless consumer calls in the built invoker.

The logic for the `eventbus.experimental.unwrapCancellableThreshold` system property remains unchanged. A future PR may adjust this so that the threshold is checked *after* listener elimination, I haven't done this yet as I'd like to first ensure the invoker build times aren't too badly affected from doing so.