### PR TITLE
Account for child `EventBus`es in `dispose()` and `trim()`

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/internal/AbstractEventBusImpl.java
+++ b/src/main/java/net/minecraftforge/eventbus/internal/AbstractEventBusImpl.java
@@ -141,8 +141,9 @@ public sealed interface AbstractEventBusImpl<T extends Event, I> extends EventBu
             // Force invalidate the invoker to remove the no-op invoker that might've been set by shutdown()
             alreadyInvalidated().set(false);
             invalidateInvoker();
+
+            children().forEach(AbstractEventBusImpl::startup);
         }
-        children().forEach(AbstractEventBusImpl::startup);
     }
 
     default void shutdown() {
@@ -154,8 +155,9 @@ public sealed interface AbstractEventBusImpl<T extends Event, I> extends EventBu
             // on calls to addListener() to keep the no-op invoker
             setNoOpInvoker();
             alreadyInvalidated().set(true);
+
+            children().forEach(AbstractEventBusImpl::shutdown);
         }
-        children().forEach(AbstractEventBusImpl::shutdown);
     }
 
     default void dispose() {
@@ -166,14 +168,22 @@ public sealed interface AbstractEventBusImpl<T extends Event, I> extends EventBu
 
             backingList().trimToSize();
             monitorBackingList().trimToSize();
+
+            children().forEach(AbstractEventBusImpl::dispose);
+
+            if (children() instanceof ArrayList<?> childrenArrayList) {
+                childrenArrayList.clear();
+                childrenArrayList.trimToSize();
+            }
         }
-        children().forEach(AbstractEventBusImpl::dispose);
     }
 
     default void trim() {
         synchronized (backingList()) {
             backingList().trimToSize();
             monitorBackingList().trimToSize();
+            if (children() instanceof ArrayList<?> childrenArrayList)
+                childrenArrayList.trimToSize();
         }
     }
 


### PR DESCRIPTION
This PR saves some more memory when calling `dispose()` and `trim()` - especially for `non-sealed`, non-`final` `InheritableEvent`s with at least one child - in that case, the list of children would be 10 elements long (the default size of `new ArrayList<>()` after adding an element).

https://github.com/MinecraftForge/EventBus/blob/b16bcf7a1316f3c17fb4c6e9607837f84c16eb7f/src/main/java/net/minecraftforge/eventbus/internal/AbstractEventBusImpl.java#L49-L62