### PR TITLE
[6.2.x] Strip redundant wrapped post-time listener checks

### DIFF
--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/events/CancelableEvent.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/events/CancelableEvent.java
@@ -9,4 +9,4 @@ import net.minecraftforge.eventbus.api.Cancelable;
 import net.minecraftforge.eventbus.api.Event;
 
 @Cancelable
-public class CancelableEvent extends Event { }
+public final class CancelableEvent extends Event {}

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/events/EventWithData.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/events/EventWithData.java
@@ -7,7 +7,7 @@ package net.minecraftforge.eventbus.testjar.events;
 
 import net.minecraftforge.eventbus.api.Event;
 
-public class EventWithData extends Event {
+public final class EventWithData extends Event {
     private final String data;
     private final int foo;
     private final boolean bar;

--- a/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/events/ResultEvent.java
+++ b/eventbus-test-jar/src/main/java/net/minecraftforge/eventbus/testjar/events/ResultEvent.java
@@ -8,4 +8,4 @@ package net.minecraftforge.eventbus.testjar.events;
 import net.minecraftforge.eventbus.api.Event;
 
 @Event.HasResult
-public class ResultEvent extends Event { }
+public final class ResultEvent extends Event {}

--- a/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
@@ -76,7 +76,8 @@ public class ASMEventHandler implements IEventListener {
     public static ASMEventHandler of(IEventListenerFactory factory, Object target, Method method, boolean isGeneric) throws IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException, ClassNotFoundException {
         var subInfo = method.getAnnotation(SubscribeEvent.class);
         assert subInfo != null;
-        if (isGeneric || EventListenerHelper.isCancelable(method.getParameterTypes()[0]))
+        var eventType = method.getParameterTypes()[0];
+        if (isGeneric || !Modifier.isFinal(eventType.getModifiers()) || EventListenerHelper.isCancelable(eventType))
             return new ASMEventHandler(factory, target, method, isGeneric, subInfo);
 
         // If we get to this point, no post-time checks are needed, so strip them out

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -252,7 +252,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
         }
 
         @SuppressWarnings("unchecked")
-        IEventListener listener = !EventListenerHelper.isCancelable(eventClass) && (filter == checkCancelled || filter == null)
+        IEventListener listener = Modifier.isFinal(eventClass.getModifiers()) && (filter == checkCancelled || filter == null) && !EventListenerHelper.isCancelable(eventClass)
                 ? e -> consumer.accept((T) e)
                 : e -> doCastFilter(filter, eventClass, consumer, e);
 

--- a/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
@@ -7,6 +7,7 @@ package net.minecraftforge.eventbus.api;
 import net.minecraftforge.eventbus.ListenerList;
 import net.minecraftforge.eventbus.api.Event.HasResult;
 import net.minecraftforge.eventbus.internal.Cache;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -63,7 +64,8 @@ public class EventListenerHelper {
         }
     }
 
-    static boolean isCancelable(Class<?> eventClass) {
+    @ApiStatus.Internal
+    public static boolean isCancelable(Class<?> eventClass) {
         return hasAnnotation(eventClass, Cancelable.class, cancelable);
     }
 


### PR DESCRIPTION
This optimisation strips out some field reads and null checks for each listener at post-time when the event is final, not annotated with `@Cancelable` and not a subclass of `GenericEvent`, instead doing these checks at registration time.

To help reduce the risk of megamorphic calls negating this optimisation, the stripping does not apply for `receiveCanceled` listeners on `@Cancelable` events.

This is somewhat similar to EventBus 7's handling of cancellable vs non-cancellable events, but much more basic as it has no knowledge of the other listeners on the ListenerList and needs to maintain backwards-compatibility with existing behaviour (such as your listener not being called when the subclass of the event type you're listening to is cancellable but not the event type itself), among other things such as not being able to account for the sealed class hierarchy of events due to targeting Java 16.

Draft pending more comprehensive benchmarks