### PR TITLE
[7.0] Introduce compile-time validation, enhance strict runtime checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ repositories {
 
 dependencies {
     implementation "net.minecraftforge:eventbus:<version>"
+    annotationProcessor "net.minecraftforge:eventbus-validator:<version>"
 }
 ```
 
@@ -53,6 +54,30 @@ this means that everything is non-null by default unless otherwise specified.
 Attempting to pass a `null` value to a method param that isn't explicitly marked as `@Nullable` is an unsupported
 operation and won't be considered a breaking change if a future version throws an exception in such cases when it didn't
 before.
+
+## Validation
+To improve startup performance, EventBus 7 relies heavily on dev-time static analysis and compile-time validation to
+ensure correct API usage, reducing the need for runtime checks. This also helps catch potential issues early on and
+provides more informative error messages that suggest solutions.
+
+It is highly recommended to use the `eventbus-validator` annotation processor during development to enable enhanced
+validation.
+
+### Runtime checks
+EventBus performs limited validation at runtime and assumes API usage is mostly correct. Incorrect usage of the API may
+lead to unexpected behaviour and breaking changes when updating EventBus due to reliance on internal implementation
+details.
+
+For use-cases where you need to debug issues in production or are unable to use the annotation processor, you can enable
+strict runtime checks by setting the `eventbus.api.strictRuntimeChecks` system property to `true` when launching your
+application. This will enable more exhaustive runtime checks for most API usage, including bulk registration of
+listeners and EventBus creation, but not field declarations.
+
+Alternatively, you can selectively enable strict runtime checks for specific subsets of the API by using the
+`eventbus.api.strictRegistrationChecks` and `eventbus.api.strictBusCreationChecks` system properties for bulk
+registration and EventBus creation, respectively. This may be useful if you only intend on adding listeners to an
+existing event made by another library, where you don't need strict checks for the creation of its associated EventBus
+due to it being outside your control.
 
 ## Contributing
 One of the main goals of EventBus is performance. As such, any changes should be benchmarked with the `jmh` Gradle task

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 
 // Define an event and a bus for it
-record PlayerLoggedInEvent(String username) implements RecordEvent {
+public record PlayerLoggedInEvent(String username) implements RecordEvent {
     public static final EventBus<PlayerLoggedInEvent> BUS = EventBus.create(PlayerLoggedInEvent.class);
 }
 

--- a/eventbus-test/build.gradle
+++ b/eventbus-test/build.gradle
@@ -19,17 +19,22 @@ license {
 dependencies {
     testImplementation rootProject
     testImplementation projects.eventbusTestJar
+    testImplementation projects.eventbusValidator
     testImplementation libs.junit.api
     testImplementation libs.jspecify.annotations
+    testImplementation libs.compile.testing
+    testImplementation libs.jetbrains.annotations
     testRuntimeOnly libs.bundles.junit.runtime
 }
 
 extraJavaModuleInfo {
     failOnMissingModuleInfo = false
+    automaticModule(libs.compile.testing, "compile.testing")
 }
 
 tasks.named('test', Test) {
     useJUnitPlatform()
+    systemProperties = ['eventbus.api.strictRuntimeChecks': true]
 }
 
 tasks.register('testAll', AggregateTest) {

--- a/eventbus-test/build.gradle
+++ b/eventbus-test/build.gradle
@@ -34,20 +34,9 @@ extraJavaModuleInfo {
     automaticModule(libs.compile.testing, "compile.testing")
 }
 
-@Field
-static final String MODULE_ARG = 'net.minecraftforge.eventbus/net.minecraftforge.eventbus.internal=net.minecraftforge.eventbus.test'
-
-tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs.addAll(['--add-exports', MODULE_ARG])
-}
-
 tasks.named('test', Test) {
     useJUnitPlatform()
     systemProperties = ['eventbus.api.strictBusCreationChecks': true]
-    jvmArgs = [
-        '--add-opens', MODULE_ARG,
-        '--add-exports', MODULE_ARG
-    ]
 }
 
 tasks.register('testAll', AggregateTest) {

--- a/eventbus-test/build.gradle
+++ b/eventbus-test/build.gradle
@@ -1,5 +1,3 @@
-import groovy.transform.Field
-
 plugins {
     id 'eclipse'
     id 'java-library'

--- a/eventbus-test/build.gradle
+++ b/eventbus-test/build.gradle
@@ -35,19 +35,19 @@ extraJavaModuleInfo {
 }
 
 @Field
-static final List<String> JVM_ARGS_FOR_TESTS = List.of(
-        '--add-opens', 'net.minecraftforge.eventbus/net.minecraftforge.eventbus.internal=net.minecraftforge.eventbus.test',
-        '--add-exports', 'net.minecraftforge.eventbus/net.minecraftforge.eventbus.internal=net.minecraftforge.eventbus.test',
-)
+static final String MODULE_ARG = 'net.minecraftforge.eventbus/net.minecraftforge.eventbus.internal=net.minecraftforge.eventbus.test'
 
 tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs.addAll(JVM_ARGS_FOR_TESTS)
+    options.compilerArgs.addAll(['--add-exports', MODULE_ARG])
 }
 
 tasks.named('test', Test) {
     useJUnitPlatform()
-    systemProperties = ['eventbus.api.strictRuntimeChecks': 'true']
-    jvmArgs JVM_ARGS_FOR_TESTS
+    systemProperties = ['eventbus.api.strictBusCreationChecks': true]
+    jvmArgs = [
+        '--add-opens', MODULE_ARG,
+        '--add-exports', MODULE_ARG
+    ]
 }
 
 tasks.register('testAll', AggregateTest) {

--- a/eventbus-test/build.gradle
+++ b/eventbus-test/build.gradle
@@ -1,3 +1,5 @@
+import groovy.transform.Field
+
 plugins {
     id 'eclipse'
     id 'java-library'
@@ -32,9 +34,20 @@ extraJavaModuleInfo {
     automaticModule(libs.compile.testing, "compile.testing")
 }
 
+@Field
+static final List<String> JVM_ARGS_FOR_TESTS = List.of(
+        '--add-opens', 'net.minecraftforge.eventbus/net.minecraftforge.eventbus.internal=net.minecraftforge.eventbus.test',
+        '--add-exports', 'net.minecraftforge.eventbus/net.minecraftforge.eventbus.internal=net.minecraftforge.eventbus.test',
+)
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs.addAll(JVM_ARGS_FOR_TESTS)
+}
+
 tasks.named('test', Test) {
     useJUnitPlatform()
-    systemProperties = ['eventbus.api.strictRuntimeChecks': true]
+    systemProperties = ['eventbus.api.strictRuntimeChecks': 'true']
+    jvmArgs JVM_ARGS_FOR_TESTS
 }
 
 tasks.register('testAll', AggregateTest) {

--- a/eventbus-test/src/test/java/module-info.java
+++ b/eventbus-test/src/test/java/module-info.java
@@ -4,8 +4,13 @@
  */
 open module net.minecraftforge.eventbus.test {
     requires net.minecraftforge.eventbus;
+    requires net.minecraftforge.eventbus.validator;
     requires org.junit.jupiter.api;
     requires org.jspecify;
+    requires java.compiler;
+    requires compile.testing;
+    requires org.jetbrains.annotations;
+    requires net.minecraftforge.eventbus.testjars;
 
     exports net.minecraftforge.eventbus.test;
 }

--- a/eventbus-test/src/test/java/module-info.java
+++ b/eventbus-test/src/test/java/module-info.java
@@ -13,4 +13,5 @@ open module net.minecraftforge.eventbus.test {
     requires net.minecraftforge.eventbus.testjars;
 
     exports net.minecraftforge.eventbus.test;
+    exports net.minecraftforge.eventbus.test.compiletime;
 }

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/BulkEventListenerTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/BulkEventListenerTests.java
@@ -288,7 +288,7 @@ public class BulkEventListenerTests {
             monitoringCalled = true;
         }
 
-        @SubscribeEvent
+        @SubscribeEvent(priority = Priority.MONITOR)
         public static void cancellationAwareMonitoringListener(CancellableTestEvent event, boolean wasCancelled) {
             cancellationAwareMonitoringCalled = true;
         }

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/BulkEventListenerTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/BulkEventListenerTests.java
@@ -653,7 +653,7 @@ public class BulkEventListenerTests {
     }
 
     /**
-     * Tests that strict bulk registeration on a class with a non-monitoring priority on a cancellation-aware monitoring event listener method throws an exception.
+     * Tests that strict bulk registration on a class with a non-monitoring priority on a cancellation-aware monitoring event listener method throws an exception.
      */
     @Test
     public void testStrictBulkRegistrationValidationWrongPriorityMonitoring() {

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/CompileTestHelper.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/CompileTestHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.eventbus.test.compiletime;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.testjar.events.EventWithData;
+import net.minecraftforge.eventbus.validator.EventBusValidator;
+import net.minecraftforge.eventbus.validator.EventTypeValidator;
+import net.minecraftforge.eventbus.validator.SubscribeEventValidator;
+import org.intellij.lang.annotations.Language;
+import org.jspecify.annotations.NullMarked;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.List;
+
+final class CompileTestHelper {
+    private CompileTestHelper() {}
+
+    private static final List<File> CLASSPATH;
+
+    @Language("Java")
+    static final String SOURCE_PREFIX = """
+            import net.minecraftforge.eventbus.api.bus.*;
+            import net.minecraftforge.eventbus.api.event.*;
+            import net.minecraftforge.eventbus.api.event.characteristic.*;
+            import net.minecraftforge.eventbus.api.listener.*;
+            
+            import net.minecraftforge.eventbus.testjar.events.*;
+            
+            import org.jspecify.annotations.NullMarked;
+            import org.jspecify.annotations.Nullable;
+            
+            @NullMarked
+            """;
+
+    static {
+        try {
+            CLASSPATH = List.of(
+                    Path.of(EventBus.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toFile(),
+                    Path.of(EventWithData.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toFile(),
+                    Path.of(NullMarked.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toFile()
+            );
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Compilation compile(@Language(value = "Java", prefix = SOURCE_PREFIX) String sourceCode) {
+        return compileWithoutDefaultPrefix(SOURCE_PREFIX + sourceCode);
+    }
+
+    static Compilation compileWithoutDefaultPrefix(@Language(value = "Java") String sourceCode) {
+        return Compiler.javac()
+                .withProcessors(new EventBusValidator(), new EventTypeValidator(), new SubscribeEventValidator())
+                .withClasspath(CLASSPATH)
+                .compile(JavaFileObjects.forSourceString("", sourceCode));
+    }
+}

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/CompileTestHelper.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/CompileTestHelper.java
@@ -43,13 +43,22 @@ final class CompileTestHelper {
     static {
         try {
             CLASSPATH = List.of(
-                    Path.of(EventBus.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toFile(),
-                    Path.of(EventWithData.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toFile(),
-                    Path.of(NullMarked.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toFile()
+                    getClassPath(EventBus.class).toFile(),
+                    getClassPath(EventWithData.class).toFile(),
+                    getClassPath(NullMarked.class).toFile()
             );
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static Path getClassPath(Class<?> clazz) throws URISyntaxException {
+        return Path.of(clazz
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .toURI()
+        );
     }
 
     static Compilation compile(@Language(value = "Java", prefix = SOURCE_PREFIX) String sourceCode) {

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/EventBusValidatorTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/EventBusValidatorTests.java
@@ -10,6 +10,9 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import static net.minecraftforge.eventbus.test.compiletime.CompileTestHelper.compile;
 
 public class EventBusValidatorTests {
+    /**
+     * Tests that compile-time validation emits a warning for EventBus fields that are not final.
+     */
     @Test
     public void testBusFieldModifiers() {
         var compilation = compile("""
@@ -20,6 +23,9 @@ public class EventBusValidatorTests {
         assertThat(compilation).hadWarningContaining("should be final");
     }
 
+    /**
+     * Tests that compile-time validation emits a warning for EventBus fields that are not of the correct type.
+     */
     @Test
     public void testBusFieldType() {
         var compilation = compile("""

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/EventBusValidatorTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/EventBusValidatorTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.eventbus.test.compiletime;
+
+import org.junit.jupiter.api.Test;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static net.minecraftforge.eventbus.test.compiletime.CompileTestHelper.compile;
+
+public class EventBusValidatorTests {
+    @Test
+    public void testBusFieldModifiers() {
+        var compilation = compile("""
+            record RecordTestEvent() implements RecordEvent {
+                static EventBus<RecordTestEvent> BUS = EventBus.create(RecordTestEvent.class);
+            }
+        """);
+        assertThat(compilation).hadWarningContaining("should be final");
+    }
+
+    @Test
+    public void testBusFieldType() {
+        var compilation = compile("""
+            record CancellableEvent() implements Cancellable, RecordEvent {
+                static final EventBus<CancellableEvent> BUS = EventBus.create(CancellableEvent.class);
+            }
+        """);
+        assertThat(compilation).hadWarningContaining("should be CancellableEventBus");
+    }
+}

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/EventTypeValidatorTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/EventTypeValidatorTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.eventbus.test.compiletime;
+
+import org.junit.jupiter.api.Test;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static net.minecraftforge.eventbus.test.compiletime.CompileTestHelper.compile;
+
+public class EventTypeValidatorTests {
+    @Test
+    public void testRecordEventValidation() {
+        var compilation = compile("final class ClassTestEvent implements RecordEvent {}");
+        assertThat(compilation).hadErrorContaining("implements RecordEvent but is not a record class");
+
+        compilation = compile("record RecordTestEvent() implements RecordEvent {}");
+        assertThat(compilation).succeededWithoutWarnings();
+    }
+
+    @Test
+    public void testMonitorAwareValidation() {
+        var compilation = compile("record RecordTestEvent() implements RecordEvent, MonitorAware {}");
+        assertThat(compilation).hadErrorContaining("implements MonitorAware but is not a mutable event");
+
+        compilation = compile("final class ClassTestEvent extends MutableEvent implements MonitorAware {}");
+        assertThat(compilation).succeededWithoutWarnings();
+    }
+
+    @Test
+    public void testInheritableEventValidation() {
+        var compilation = compile("final class ClassTestEvent implements InheritableEvent {}");
+        assertThat(compilation).hadErrorContaining("directly implements InheritableEvent but is not inheritable - extend MutableEvent instead");
+
+        compilation = compile("record RecordTestEvent() implements InheritableEvent {}");
+        assertThat(compilation).hadErrorContaining("directly implements InheritableEvent but is not inheritable - implement RecordEvent instead");
+
+        compilation = compile("final class ClassTestEvent extends MutableEvent {}");
+        assertThat(compilation).succeededWithoutWarnings();
+    }
+}

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/EventTypeValidatorTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/EventTypeValidatorTests.java
@@ -10,6 +10,9 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import static net.minecraftforge.eventbus.test.compiletime.CompileTestHelper.compile;
 
 public class EventTypeValidatorTests {
+    /**
+     * Tests that compile-time validation throws an error for non-record classes that implement RecordEvent.
+     */
     @Test
     public void testRecordEventValidation() {
         var compilation = compile("final class ClassTestEvent implements RecordEvent {}");
@@ -19,6 +22,9 @@ public class EventTypeValidatorTests {
         assertThat(compilation).succeededWithoutWarnings();
     }
 
+    /**
+     * Tests that compile-time validation throws an error for MonitorAware on classes that do not extend MutableEvent.
+     */
     @Test
     public void testMonitorAwareValidation() {
         var compilation = compile("record RecordTestEvent() implements RecordEvent, MonitorAware {}");
@@ -28,6 +34,9 @@ public class EventTypeValidatorTests {
         assertThat(compilation).succeededWithoutWarnings();
     }
 
+    /**
+     * Tests that compile-time validation throws an error for InheritableEvent on classes that are not inheritable.
+     */
     @Test
     public void testInheritableEventValidation() {
         var compilation = compile("final class ClassTestEvent implements InheritableEvent {}");

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/SubscribeEventValidatorTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/SubscribeEventValidatorTests.java
@@ -40,8 +40,11 @@ public class SubscribeEventValidatorTests {
 
     @Test
     public void testSubscribeEventReturnType() {
-        var compilation = compile("@SubscribeEvent int invalidReturnType(EventWithData a) { return 0; }");
+        var compilation = compile("@SubscribeEvent int invalidReturnType(EventWithData event) { return 0; }");
         assertThat(compilation).hadErrorContaining("expected void");
+
+        compilation = compile("@SubscribeEvent boolean neverCancellingEvent(CancelableEvent event) { return false; }");
+        assertThat(compilation).hadWarningContaining("consider using a void return type");
     }
 
     // Todo: The rest of the tests

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/SubscribeEventValidatorTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/SubscribeEventValidatorTests.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
 package net.minecraftforge.eventbus.test.compiletime;
 
 import com.google.testing.compile.Compilation;

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/SubscribeEventValidatorTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/SubscribeEventValidatorTests.java
@@ -5,6 +5,7 @@
 package net.minecraftforge.eventbus.test.compiletime;
 
 import com.google.testing.compile.Compilation;
+import net.minecraftforge.eventbus.test.BulkEventListenerTests;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +19,23 @@ public class SubscribeEventValidatorTests {
         return CompileTestHelper.compileWithoutDefaultPrefix(SOURCE_PREFIX + sourceCode + "}");
     }
 
+    /**
+     * Tests that compile-time validation of parameter types on methods annotated with @SubscribeEvent works correctly.
+     * @see BulkEventListenerTests#testStrictBulkRegistrationValidationWrongParameterType()
+     */
+    @Test
+    public void testSubscribeEventParamTypes() {
+        var compilation = compile("@SubscribeEvent void wrongFirstParamType(String notAnEvent) {}");
+        assertThat(compilation).hadErrorContaining("must be an event");
+
+        compilation = compile("@SubscribeEvent void correctFirstParam(EventWithData event) {}");
+        assertThat(compilation).succeededWithoutWarnings();
+    }
+
+    /**
+     * Tests that compile-time validation of parameter count on methods annotated with @SubscribeEvent works correctly.
+     * @see BulkEventListenerTests#testStrictBulkRegistrationValidationWrongParameterCount()
+     */
     @Test
     public void testSubscribeEventParamCount() {
         var compilation = compile("@SubscribeEvent void noParameters() {}");
@@ -27,29 +45,121 @@ public class SubscribeEventValidatorTests {
         assertThat(compilation).hadErrorContaining("Invalid number of parameters");
     }
 
-    @Test
-    public void testSubscribeEventParamTypes() {
-        var compilation = compile("@SubscribeEvent void wrongFirstParamType(String notAnEvent) {}");
-        assertThat(compilation).hadErrorContaining("must be an event");
-
-        compilation = compile("@SubscribeEvent void correctFirstParam(EventWithData event) {}");
-        assertThat(compilation).succeededWithoutWarnings();
-
-        compilation = compile("@SubscribeEvent void wrongSecondParamType(EventWithData event, String notABoolean) {}");
-        assertThat(compilation).hadErrorContaining("must be a boolean");
-
-        compilation = compile("@SubscribeEvent void wrongParamTypes(EventWithData event, boolean wasCancelled) {}");
-        assertThat(compilation).hadErrorContaining("only valid for cancellable events");
-    }
-
+    /**
+     * Tests that compile-time validation of the return type on methods annotated with @SubscribeEvent works correctly.
+     * @see BulkEventListenerTests#testStrictBulkRegistrationValidationWrongReturnType()
+     */
     @Test
     public void testSubscribeEventReturnType() {
         var compilation = compile("@SubscribeEvent int invalidReturnType(EventWithData event) { return 0; }");
         assertThat(compilation).hadErrorContaining("expected void");
-
-        compilation = compile("@SubscribeEvent boolean neverCancellingEvent(CancelableEvent event) { return false; }");
-        assertThat(compilation).hadWarningContaining("consider using a void return type");
     }
 
-    // Todo: The rest of the tests
+    /**
+     * Tests that compile-time validation of the return type on methods annotated with @SubscribeEvent for cancellable
+     * events and listeners works correctly
+     * @see BulkEventListenerTests#testStrictBulkRegistrationValidationWrongReturnTypeCancellable()
+     */
+    @Test
+    public void testSubscribeEventReturnTypeCancellable() {
+        var compilation = compile("""
+            @SubscribeEvent
+            boolean invalidReturnType(EventWithData event) { return false; }
+        """);
+        assertThat(compilation).hadErrorContaining("boolean is only valid for cancellable events");
+
+        compilation = compile("""
+            @SubscribeEvent
+            boolean neverCancellingEvent(CancelableEvent event) { return false; }
+        """);
+        assertThat(compilation).hadWarningContaining("consider using a void return type");
+
+        compilation = compile("""
+            @SubscribeEvent(alwaysCancelling = true)
+            void alwaysCancellingEvent(CancelableEvent event) {}
+        """);
+        assertThat(compilation).succeededWithoutWarnings();
+
+        compilation = compile("""
+            static final java.util.Random RANDOM = new java.util.Random();
+        
+            @SubscribeEvent
+            boolean possiblyCancellingEvent(CancelableEvent event) { return RANDOM.nextBoolean(); }
+        """);
+        assertThat(compilation).succeededWithoutWarnings();
+    }
+
+    /**
+     * Tests that compile-time validation of the return type on methods annotated with @SubscribeEvent for monitoring
+     * listeners works correctly.
+     * @see BulkEventListenerTests#testStrictBulkRegistrationValidationWrongReturnTypeMonitoring()
+     */
+    @Test
+    public void testSubscribeEventReturnTypeMonitoring() {
+        var compilation = compile("""
+            @SubscribeEvent(priority = Priority.MONITOR)
+            boolean possiblyCancellingMonitor(CancelableEvent event) { return false; }
+        """);
+        assertThat(compilation).hadErrorContaining("Monitoring listeners cannot cancel events");
+
+        compilation = compile("""
+            @SubscribeEvent(priority = Priority.MONITOR, alwaysCancelling = true)
+            void alwaysCancellingMonitor(CancelableEvent event) {}
+        """);
+        assertThat(compilation).hadErrorContaining("Monitoring listeners cannot cancel events");
+    }
+
+    /**
+     * Tests that compile-time validation of the parameter type on methods annotated with @SubscribeEvent for monitoring
+     * listeners works correctly.
+     * @see BulkEventListenerTests#testStrictBulkRegistrationValidationWrongParamTypeMonitoring()
+     */
+    @Test
+    public void testSubscribeEventParamTypeMonitoring() {
+        var compilation = compile("""
+            @SubscribeEvent(priority = Priority.MONITOR)
+            void monitoringListener(CancelableEvent event, int wrong) {}
+        """);
+        assertThat(compilation).hadErrorContaining("must be a boolean");
+
+        compilation = compile("""
+            @SubscribeEvent(priority = Priority.MONITOR)
+            void monitoringListener(CancelableEvent event) {}
+        """);
+        assertThat(compilation).succeededWithoutWarnings();
+    }
+
+    /**
+     * Tests that compile-time validation of the parameter count on methods annotated with @SubscribeEvent for
+     * cancellation-aware monitoring listeners works correctly.
+     * @see BulkEventListenerTests#testStrictBulkRegistrationValidationWrongParamCountMonitoring()
+     */
+    @Test
+    public void testSubscribeEventParamCountMonitoring() {
+        var compilation = compile("""
+            @SubscribeEvent(priority = Priority.MONITOR)
+            void monitoringListener(EventWithData event, boolean wasCancelled) {}
+        """);
+        assertThat(compilation).hadErrorContaining("Cancellation-aware monitoring listeners are only valid for cancellable events");
+
+        compilation = compile("""
+            @SubscribeEvent(priority = Priority.MONITOR)
+            void cancellationAwareMonitoringListener(CancelableEvent event, boolean wasCancelled) {}
+        """);
+        assertThat(compilation).succeededWithoutWarnings();
+    }
+
+    /**
+     * Tests that compile-time validation of the priority on methods annotated with @SubscribeEvent for
+     * cancellation-aware monitoring listeners works correctly.
+     * @see BulkEventListenerTests#testStrictBulkRegistrationValidationWrongPriorityMonitoring()
+     */
+    @Test
+    public void testSubscribeEventPriorityMonitoring() {
+        var compilation = compile("""
+            @SubscribeEvent(priority = Priority.LOWEST)
+            void cancellationAwareMonitoringListener(CancelableEvent event, boolean wasCancelled) {}
+        """);
+        assertThat(compilation).hadErrorContaining("must have a priority of MONITOR");
+    }
 }

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/SubscribeEventValidatorTests.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/compiletime/SubscribeEventValidatorTests.java
@@ -1,0 +1,48 @@
+package net.minecraftforge.eventbus.test.compiletime;
+
+import com.google.testing.compile.Compilation;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+public class SubscribeEventValidatorTests {
+    @Language(value = "Java", suffix = "}")
+    private static final String SOURCE_PREFIX = CompileTestHelper.SOURCE_PREFIX + "final class Listeners {";
+
+    private static Compilation compile(@Language(value = "Java", prefix = SOURCE_PREFIX, suffix = "}") String sourceCode) {
+        return CompileTestHelper.compileWithoutDefaultPrefix(SOURCE_PREFIX + sourceCode + "}");
+    }
+
+    @Test
+    public void testSubscribeEventParamCount() {
+        var compilation = compile("@SubscribeEvent void noParameters() {}");
+        assertThat(compilation).hadErrorContaining("Invalid number of parameters");
+
+        compilation = compile("@SubscribeEvent void tooManyParameters(int a, int b, int c) {}");
+        assertThat(compilation).hadErrorContaining("Invalid number of parameters");
+    }
+
+    @Test
+    public void testSubscribeEventParamTypes() {
+        var compilation = compile("@SubscribeEvent void wrongFirstParamType(String notAnEvent) {}");
+        assertThat(compilation).hadErrorContaining("must be an event");
+
+        compilation = compile("@SubscribeEvent void correctFirstParam(EventWithData event) {}");
+        assertThat(compilation).succeededWithoutWarnings();
+
+        compilation = compile("@SubscribeEvent void wrongSecondParamType(EventWithData event, String notABoolean) {}");
+        assertThat(compilation).hadErrorContaining("must be a boolean");
+
+        compilation = compile("@SubscribeEvent void wrongParamTypes(EventWithData event, boolean wasCancelled) {}");
+        assertThat(compilation).hadErrorContaining("only valid for cancellable events");
+    }
+
+    @Test
+    public void testSubscribeEventReturnType() {
+        var compilation = compile("@SubscribeEvent int invalidReturnType(EventWithData a) { return 0; }");
+        assertThat(compilation).hadErrorContaining("expected void");
+    }
+
+    // Todo: The rest of the tests
+}

--- a/eventbus-validator/build.gradle
+++ b/eventbus-validator/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java-library'
+    id 'maven-publish'
     alias libs.plugins.gradleutils
     alias libs.plugins.licenser
 }
@@ -17,4 +18,27 @@ license {
     newLine = false
 }
 
-// todo: verify publishing works
+publishing {
+    publications.register('validatorMavenJava', MavenPublication) {
+        from components.java
+        artifactId = 'eventbus-validator'
+        groupId = 'net.minecraftforge'
+        version = rootProject.version.toString()
+        pom {
+            name = 'EventBus Validator'
+            description = 'A compile-time validator for EventBus API usages'
+
+            licenses {
+                license gradleutils.pom.licenses.LGPLv2_1
+            }
+
+            developers {
+                developer gradleutils.pom.developers.Paint_Ninja
+            }
+        }
+    }
+
+    repositories {
+        maven gradleutils.publishingForgeMaven
+    }
+}

--- a/eventbus-validator/build.gradle
+++ b/eventbus-validator/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java-library'
+    alias libs.plugins.gradleutils
+    alias libs.plugins.licenser
+}
+
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
+}
+
+dependencies {
+    implementation rootProject
+}
+
+license {
+    header = rootProject.file('LICENSE-header.txt')
+    newLine = false
+}
+
+// todo: verify publishing works

--- a/eventbus-validator/src/main/java/module-info.java
+++ b/eventbus-validator/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+import net.minecraftforge.eventbus.validator.*;
+
+module net.minecraftforge.eventbus.validator {
+    requires java.compiler;
+    requires jdk.compiler;
+    requires net.minecraftforge.eventbus;
+
+    exports net.minecraftforge.eventbus.validator;
+
+    provides javax.annotation.processing.Processor with EventTypeValidator, EventBusValidator, SubscribeEventValidator;
+}

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/AbstractValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/AbstractValidator.java
@@ -11,7 +11,6 @@ import net.minecraftforge.eventbus.api.event.MutableEvent;
 import net.minecraftforge.eventbus.api.event.RecordEvent;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
 import net.minecraftforge.eventbus.api.event.characteristic.MonitorAware;
-import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
 
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -40,8 +39,6 @@ abstract sealed class AbstractValidator implements Processor
         private EventCharacteristics() {}
 
         protected static TypeMirror cancellable;
-        protected static TypeMirror inheritable;
-        protected static TypeMirror selfDestructing;
         protected static TypeMirror monitorAware;
     }
 
@@ -78,8 +75,6 @@ abstract sealed class AbstractValidator implements Processor
         EventTypes.recordEvent = elements.getTypeElement(RecordEvent.class.getCanonicalName()).asType();
         EventTypes.mutableEvent = elements.getTypeElement(MutableEvent.class.getCanonicalName()).asType();
         EventCharacteristics.cancellable = elements.getTypeElement(Cancellable.class.getCanonicalName()).asType();
-        EventCharacteristics.inheritable = elements.getTypeElement(InheritableEvent.class.getCanonicalName()).asType();
-        EventCharacteristics.selfDestructing = elements.getTypeElement(SelfDestructing.class.getCanonicalName()).asType();
         EventCharacteristics.monitorAware = elements.getTypeElement(MonitorAware.class.getCanonicalName()).asType();
         BusTypes.eventBus = types.erasure(elements.getTypeElement(EventBus.class.getCanonicalName()).asType());
         BusTypes.cancellableEventBus = types.erasure(elements.getTypeElement(CancellableEventBus.class.getCanonicalName()).asType());

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/AbstractValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/AbstractValidator.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.eventbus.validator;
+
+import net.minecraftforge.eventbus.api.bus.CancellableEventBus;
+import net.minecraftforge.eventbus.api.bus.EventBus;
+import net.minecraftforge.eventbus.api.event.InheritableEvent;
+import net.minecraftforge.eventbus.api.event.MutableEvent;
+import net.minecraftforge.eventbus.api.event.RecordEvent;
+import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
+import net.minecraftforge.eventbus.api.event.characteristic.MonitorAware;
+import net.minecraftforge.eventbus.api.event.characteristic.SelfDestructing;
+
+import javax.annotation.processing.Completion;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeMirror;
+import java.util.List;
+import java.util.Set;
+
+abstract sealed class AbstractValidator implements Processor
+        permits EventBusValidator, EventTypeValidator, SubscribeEventValidator {
+    protected ProcessingEnvironment processingEnv;
+
+    protected static final class EventTypes {
+        private EventTypes() {}
+
+        protected static TypeMirror mutableEvent;
+        protected static TypeMirror recordEvent;
+        protected static TypeMirror inheritableEvent;
+    }
+
+    protected static final class EventCharacteristics {
+        private EventCharacteristics() {}
+
+        protected static TypeMirror cancellable;
+        protected static TypeMirror inheritable;
+        protected static TypeMirror selfDestructing;
+        protected static TypeMirror monitorAware;
+    }
+
+    protected static final class BusTypes {
+        private BusTypes() {}
+
+        protected static TypeMirror eventBus;
+        protected static TypeMirror cancellableEventBus;
+    }
+
+    protected AbstractValidator() {}
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of("*");
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public void init(ProcessingEnvironment processingEnv) {
+        this.processingEnv = processingEnv;
+        var elements = processingEnv.getElementUtils();
+        var types = processingEnv.getTypeUtils();
+        EventTypes.inheritableEvent = elements.getTypeElement(InheritableEvent.class.getCanonicalName()).asType();
+        EventTypes.recordEvent = elements.getTypeElement(RecordEvent.class.getCanonicalName()).asType();
+        EventTypes.mutableEvent = elements.getTypeElement(MutableEvent.class.getCanonicalName()).asType();
+        EventCharacteristics.cancellable = elements.getTypeElement(Cancellable.class.getCanonicalName()).asType();
+        EventCharacteristics.inheritable = elements.getTypeElement(InheritableEvent.class.getCanonicalName()).asType();
+        EventCharacteristics.selfDestructing = elements.getTypeElement(SelfDestructing.class.getCanonicalName()).asType();
+        EventCharacteristics.monitorAware = elements.getTypeElement(MonitorAware.class.getCanonicalName()).asType();
+        BusTypes.eventBus = types.erasure(elements.getTypeElement(EventBus.class.getCanonicalName()).asType());
+        BusTypes.cancellableEventBus = types.erasure(elements.getTypeElement(CancellableEventBus.class.getCanonicalName()).asType());
+    }
+
+    @Override
+    public Iterable<? extends Completion> getCompletions(Element element, AnnotationMirror annotation, ExecutableElement member, String userText) {
+        return List.of();
+    }
+}

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/EventBusValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/EventBusValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.eventbus.validator;
+
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import java.util.Set;
+
+public final class EventBusValidator extends AbstractValidator {
+    private Trees trees;
+    private Types types;
+
+    @Override
+    public void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        trees = Trees.instance(processingEnv);
+        types = processingEnv.getTypeUtils();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (var root : roundEnv.getRootElements()) {
+            var path = trees.getPath(root);
+            if (path != null) new BusFieldScanner().scan(path, null);
+        }
+
+        return false; // allow other processors to run
+    }
+
+    private final class BusFieldScanner extends TreePathScanner<Void, Void> {
+        @Override
+        public Void visitVariable(VariableTree varTree, Void ignored) {
+            Element element = trees.getElement(getCurrentPath());
+            if (element.getKind() != ElementKind.FIELD)
+                return super.visitVariable(varTree, ignored); // only interested in fields
+
+            TypeMirror erasedFieldType = types.erasure(element.asType());
+            var isStandardEventBus = types.isSameType(erasedFieldType, BusTypes.eventBus);
+            if (!(isStandardEventBus || types.isSameType(erasedFieldType, BusTypes.cancellableEventBus)))
+                return super.visitVariable(varTree, ignored); // only interested in (Cancellable)EventBus fields
+
+            // Show a warning if the bus field is not final
+            if (!element.getModifiers().contains(Modifier.FINAL)) {
+                processingEnv.getMessager().printMessage(
+                        Diagnostic.Kind.WARNING,
+                        "EventBus field " + element + " should be final",
+                        element
+                );
+            }
+
+            // Show a warning if the T in field type EventBus<T> is Cancellable (should be CancellableEventBus<T> instead)
+            if (isStandardEventBus && element.asType() instanceof DeclaredType declaredType
+                    && !declaredType.getTypeArguments().isEmpty()) {
+                var genericType = declaredType.getTypeArguments().getFirst();
+                if (types.isAssignable(genericType, EventCharacteristics.cancellable)) {
+                    processingEnv.getMessager().printMessage(
+                            Diagnostic.Kind.WARNING,
+                            """
+                            EventBus field %s should be CancellableEventBus<%s> instead of EventBus<%s> because %s inherits from Cancellable
+                            """,
+                            element
+                    );
+                }
+            }
+
+            return super.visitVariable(varTree, ignored);
+        }
+    }
+}

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/EventBusValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/EventBusValidator.java
@@ -17,7 +17,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
-import javax.tools.Diagnostic;
 import java.util.Set;
 
 public final class EventBusValidator extends AbstractValidator {
@@ -55,8 +54,7 @@ public final class EventBusValidator extends AbstractValidator {
 
             // Show a warning if the bus field is not final
             if (!element.getModifiers().contains(Modifier.FINAL)) {
-                processingEnv.getMessager().printMessage(
-                        Diagnostic.Kind.WARNING,
+                processingEnv.getMessager().printWarning(
                         "EventBus field " + element + " should be final",
                         element
                 );
@@ -67,8 +65,7 @@ public final class EventBusValidator extends AbstractValidator {
                     && !declaredType.getTypeArguments().isEmpty()) {
                 var genericType = declaredType.getTypeArguments().getFirst();
                 if (types.isAssignable(genericType, EventCharacteristics.cancellable)) {
-                    processingEnv.getMessager().printMessage(
-                            Diagnostic.Kind.WARNING,
+                    processingEnv.getMessager().printWarning(
                             """
                             EventBus field %s should be CancellableEventBus<%s> instead of EventBus<%s> because %s inherits from Cancellable
                             """,

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/EventTypeValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/EventTypeValidator.java
@@ -6,7 +6,6 @@ package net.minecraftforge.eventbus.validator;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.*;
-import javax.tools.Diagnostic;
 import java.util.Set;
 
 public final class EventTypeValidator extends AbstractValidator {
@@ -22,8 +21,7 @@ public final class EventTypeValidator extends AbstractValidator {
 
             // Check that RecordEvent is only implemented by record classes
             if (typeUtils.isAssignable(rootType, EventTypes.recordEvent) && rootKind != ElementKind.RECORD) {
-                processingEnv.getMessager().printMessage(
-                        Diagnostic.Kind.ERROR,
+                processingEnv.getMessager().printError(
                         "Event type " + rootType + " implements RecordEvent but is not a record class",
                         root
                 );
@@ -31,8 +29,7 @@ public final class EventTypeValidator extends AbstractValidator {
 
             // Check that MonitorAware is only implemented on classes that extend MutableEvent
             if (typeUtils.isAssignable(rootType, EventCharacteristics.monitorAware) && !typeUtils.isAssignable(rootType, EventTypes.mutableEvent)) {
-                processingEnv.getMessager().printMessage(
-                        Diagnostic.Kind.ERROR,
+                processingEnv.getMessager().printError(
                         "Event type " + rootType + " implements MonitorAware but is not a mutable event",
                         root
                 );
@@ -48,8 +45,7 @@ public final class EventTypeValidator extends AbstractValidator {
                 if (rootInterfaces.size() == 1 && typeUtils.isSameType(rootInterfaces.getFirst(), EventTypes.inheritableEvent)) {
                     var errorMsg = "Event type " + rootType + " directly implements InheritableEvent but is not inheritable";
                     var solution = rootKind == ElementKind.RECORD ? "implement RecordEvent instead" : "extend MutableEvent instead";
-                    processingEnv.getMessager().printMessage(
-                            Diagnostic.Kind.ERROR,
+                    processingEnv.getMessager().printError(
                             errorMsg + " - " + solution,
                             root
                     );

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/EventTypeValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/EventTypeValidator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.eventbus.validator;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.*;
+import javax.tools.Diagnostic;
+import java.util.Set;
+
+public final class EventTypeValidator extends AbstractValidator {
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        var typeUtils = processingEnv.getTypeUtils();
+        for (Element root : roundEnv.getRootElements()) {
+            var rootKind = root.getKind();
+            if (rootKind != ElementKind.CLASS && rootKind != ElementKind.INTERFACE && rootKind != ElementKind.RECORD)
+                continue;
+
+            var rootType = root.asType();
+
+            // Check that RecordEvent is only implemented by record classes
+            if (typeUtils.isAssignable(rootType, EventTypes.recordEvent) && rootKind != ElementKind.RECORD) {
+                processingEnv.getMessager().printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "Event type " + rootType + " implements RecordEvent but is not a record class",
+                        root
+                );
+            }
+
+            // Check that MonitorAware is only implemented on classes that extend MutableEvent
+            if (typeUtils.isAssignable(rootType, EventCharacteristics.monitorAware) && !typeUtils.isAssignable(rootType, EventTypes.mutableEvent)) {
+                processingEnv.getMessager().printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "Event type " + rootType + " implements MonitorAware but is not a mutable event",
+                        root
+                );
+            }
+
+            // Check that InheritableEvent is not directly implemented by classes that are not inheritable
+            var rootElement = (TypeElement) root;
+            if (typeUtils.isAssignable(rootType, EventTypes.inheritableEvent) // instanceof InheritableEvent
+                    && (rootKind == ElementKind.RECORD || rootElement.getModifiers().contains(Modifier.FINAL)) // record or final
+                    && (rootKind == ElementKind.RECORD || rootElement.getSuperclass().toString().equals(Object.class.getCanonicalName()))) { // record or no extends clause
+
+                var rootInterfaces = rootElement.getInterfaces(); // only one interface which is exactly InheritableEvent
+                if (rootInterfaces.size() == 1 && typeUtils.isSameType(rootInterfaces.getFirst(), EventTypes.inheritableEvent)) {
+                    var errorMsg = "Event type " + rootType + " directly implements InheritableEvent but is not inheritable";
+                    var solution = rootKind == ElementKind.RECORD ? "implement RecordEvent instead" : "extend MutableEvent instead";
+                    processingEnv.getMessager().printMessage(
+                            Diagnostic.Kind.ERROR,
+                            errorMsg + " - " + solution,
+                            root
+                    );
+                }
+            }
+        }
+
+        return false; // allow other processors to run
+    }
+}

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/SubscribeEventValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/SubscribeEventValidator.java
@@ -72,9 +72,9 @@ public final class SubscribeEventValidator extends AbstractValidator {
 
         var firstParamExtendsCancellable = types.isAssignable(firstParamType, EventCharacteristics.cancellable);
         var subscribeEventAnnotation = method.getAnnotation(SubscribeEvent.class);
-        var isMonitoringListener = subscribeEventAnnotation.priority() == Priority.MONITOR;
+        var isMonitoringPriority = subscribeEventAnnotation.priority() == Priority.MONITOR;
 
-        if (isMonitoringListener && (returnType.getKind() == TypeKind.BOOLEAN || subscribeEventAnnotation.alwaysCancelling()))
+        if (isMonitoringPriority && (returnType.getKind() == TypeKind.BOOLEAN || subscribeEventAnnotation.alwaysCancelling()))
             error(method, "Monitoring listeners cannot cancel events");
 
         if (paramCount == 2) {
@@ -85,7 +85,7 @@ public final class SubscribeEventValidator extends AbstractValidator {
             if (secondParamType.getKind() != TypeKind.BOOLEAN)
                 error(method, "Second parameter of a cancellation-aware monitoring listener must be a boolean");
 
-            if (subscribeEventAnnotation.priority() != Priority.MONITOR)
+            if (!isMonitoringPriority)
                 error(method, "Cancellation-aware monitoring listeners must have a priority of MONITOR");
         }
 

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/SubscribeEventValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/SubscribeEventValidator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Forge Development LLC
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.eventbus.validator;
+
+import net.minecraftforge.eventbus.api.listener.Priority;
+import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import java.util.Set;
+
+public final class SubscribeEventValidator extends AbstractValidator {
+    private Types types;
+    private TypeMirror eventType;
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(SubscribeEvent.class.getCanonicalName());
+    }
+
+    @Override
+    public void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        types = processingEnv.getTypeUtils();
+        var elements = processingEnv.getElementUtils();
+        eventType = elements.getTypeElement("net.minecraftforge.eventbus.internal.Event").asType();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (Element e : roundEnv.getElementsAnnotatedWith(SubscribeEvent.class)) {
+            if (e.getKind() == ElementKind.METHOD) {
+                validate((ExecutableElement) e);
+            }
+        }
+
+        return false; // allow other processors to run
+    }
+
+    private void validate(ExecutableElement method) {
+        int paramCount = method.getParameters().size();
+
+        if (paramCount == 0 || paramCount > 2) {
+            error(method, "Invalid number of parameters: " + paramCount + " (expected 1 or 2)");
+            return;
+        }
+
+        var firstParam = method.getParameters().getFirst();
+        var firstParamType = firstParam.asType();
+        if (!types.isAssignable(firstParamType, eventType))
+            error(method, "First parameter of a @SubscribeEvent method must be an event");
+
+        var returnType = method.getReturnType();
+        if (returnType.getKind() != TypeKind.VOID && returnType.getKind() != TypeKind.BOOLEAN)
+            error(method, "Invalid return type: " + returnType + " (expected void or boolean)");
+
+        var firstParamExtendsCancellable = types.isAssignable(firstParamType, EventCharacteristics.cancellable);
+        var subscribeEventAnnotation = method.getAnnotation(SubscribeEvent.class);
+        var isMonitoringListener = subscribeEventAnnotation.priority() == Priority.MONITOR;
+
+        if (isMonitoringListener && (returnType.getKind() == TypeKind.BOOLEAN || subscribeEventAnnotation.alwaysCancelling()))
+            error(method, "Monitoring listeners cannot cancel events");
+
+        if (paramCount == 2) {
+            if (!firstParamExtendsCancellable)
+                error(method, "Cancellation-aware monitoring listeners are only valid for cancellable events");
+
+            var secondParamType = method.getParameters().getLast().asType();
+            if (secondParamType.getKind() != TypeKind.BOOLEAN)
+                error(method, "Second parameter of a cancellation-aware monitoring listener must be a boolean");
+
+            if (subscribeEventAnnotation.priority() != Priority.MONITOR)
+                error(method, "Cancellation-aware monitoring listeners must have a priority of MONITOR");
+        }
+
+        if (!firstParamExtendsCancellable) {
+            if (subscribeEventAnnotation.alwaysCancelling())
+                error(method, "Always cancelling listeners are only valid for cancellable events");
+
+            if (returnType.getKind() == TypeKind.BOOLEAN)
+                error(method, "Return type boolean is only valid for cancellable events");
+        }
+    }
+
+    private void error(ExecutableElement method, String message) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, method);
+    }
+}

--- a/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/SubscribeEventValidator.java
+++ b/eventbus-validator/src/main/java/net/minecraftforge/eventbus/validator/SubscribeEventValidator.java
@@ -21,7 +21,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
-import javax.tools.Diagnostic;
 import java.util.Set;
 
 public final class SubscribeEventValidator extends AbstractValidator {
@@ -107,8 +106,7 @@ public final class SubscribeEventValidator extends AbstractValidator {
 
             if (scanner.sawReturn && !scanner.sawNonLiteralReturn && scanner.sawLiteralFalse && !scanner.sawLiteralTrue) {
                 // if we get here, all returns in this method are literal `return false;` statements
-                processingEnv.getMessager().printMessage(
-                        Diagnostic.Kind.WARNING,
+                processingEnv.getMessager().printWarning(
                         "Listener always returns false, consider using a void return type instead",
                         method
                 );
@@ -117,7 +115,7 @@ public final class SubscribeEventValidator extends AbstractValidator {
     }
 
     private void error(ExecutableElement method, String message) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, method);
+        processingEnv.getMessager().printError(message, method);
     }
 
     private static final class ReturnScanner extends TreePathScanner<Void, Void> {

--- a/eventbus-validator/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/eventbus-validator/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,3 @@
+net.minecraftforge.eventbus.validator.EventBusValidator
+net.minecraftforge.eventbus.validator.EventTypeValidator
+net.minecraftforge.eventbus.validator.SubscribeEventValidator

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,6 +46,9 @@ dependencyResolutionManagement {
         version 'jmh', '1.37'
         library 'jmh-core',                'org.openjdk.jmh', 'jmh-core'                 versionRef 'jmh'
         library 'jmh-annotationProcessor', 'org.openjdk.jmh', 'jmh-generator-annprocess' versionRef 'jmh'
+
+        library 'compile-testing', 'com.google.testing.compile', 'compile-testing' version '0.21.0'
+        library 'jetbrains-annotations', 'org.jetbrains', 'annotations' version '26.0.2'
     }
     //@formatter:on
 }
@@ -56,5 +59,6 @@ rootProject.name = 'EventBus'
 include 'eventbus-jmh'
 include 'eventbus-test'
 include 'eventbus-test-jar'
+include 'eventbus-validator'
 if (file('eventbus-wrapper').exists())
     include 'eventbus-wrapper'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,7 +13,4 @@ module net.minecraftforge.eventbus {
     exports net.minecraftforge.eventbus.api.event;
     exports net.minecraftforge.eventbus.api.event.characteristic;
     exports net.minecraftforge.eventbus.api.listener;
-
-    exports net.minecraftforge.eventbus.internal to net.minecraftforge.eventbus.test;
-    opens net.minecraftforge.eventbus.internal to net.minecraftforge.eventbus.test;
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,4 +13,7 @@ module net.minecraftforge.eventbus {
     exports net.minecraftforge.eventbus.api.event;
     exports net.minecraftforge.eventbus.api.event.characteristic;
     exports net.minecraftforge.eventbus.api.listener;
+
+    exports net.minecraftforge.eventbus.internal to net.minecraftforge.eventbus.test;
+    opens net.minecraftforge.eventbus.internal to net.minecraftforge.eventbus.test;
 }

--- a/src/main/java/net/minecraftforge/eventbus/internal/BusGroupImpl.java
+++ b/src/main/java/net/minecraftforge/eventbus/internal/BusGroupImpl.java
@@ -8,10 +8,10 @@ import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.eventbus.api.bus.EventBus;
 import net.minecraftforge.eventbus.api.event.*;
 import net.minecraftforge.eventbus.api.event.characteristic.Cancellable;
-import net.minecraftforge.eventbus.api.event.characteristic.MonitorAware;
 import net.minecraftforge.eventbus.api.listener.EventListener;
 
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -92,13 +92,26 @@ public record BusGroupImpl(
 //        if (eventBuses.containsKey(eventType))
 //            throw new IllegalArgumentException("EventBus for " + eventType + " already exists on BusGroup \"" + name + "\"");
 
-        if (RecordEvent.class.isAssignableFrom(eventType) && !eventType.isRecord())
-            throw new IllegalArgumentException("Event type " + eventType + " is not a record class but implements RecordEvent");
-
         int characteristics = AbstractEventBusImpl.computeEventCharacteristics(eventType);
 
-        if (Constants.isMonitorAware(characteristics) && !MutableEvent.class.isAssignableFrom(eventType))
-            throw new IllegalArgumentException("Event type " + eventType + " implements MonitorAware but is not a MutableEvent");
+        if (Constants.STRICT_BUS_CREATION_CHECKS) {
+            boolean isRecord = eventType.isRecord();
+            if (!isRecord && RecordEvent.class.isAssignableFrom(eventType))
+                throw new IllegalArgumentException("Event type " + eventType + " implements RecordEvent but is not a record class");
+
+            if (Constants.isMonitorAware(characteristics) && !MutableEvent.class.isAssignableFrom(eventType))
+                throw new IllegalArgumentException("Event type " + eventType + " implements MonitorAware but is not a MutableEvent");
+
+            if (Constants.isInheritable(characteristics) && (isRecord || Modifier.isFinal(eventType.getModifiers()))
+                    && eventType.getSuperclass() == null) {
+                var interfaces = eventType.getInterfaces();
+                if (interfaces.length == 1 && interfaces[0] == InheritableEvent.class) {
+                    var errorMsg = "Event type " + eventType + " directly implements InheritableEvent but is not inheritable";
+                    var solution = isRecord ? "implement RecordEvent instead" : "extend MutableEvent instead";
+                    throw new IllegalArgumentException(errorMsg + " - " + solution);
+                }
+            }
+        }
 
         var backingList = new ArrayList<EventListener>();
         List<EventBus<?>> parents = Collections.emptyList();

--- a/src/main/java/net/minecraftforge/eventbus/internal/Constants.java
+++ b/src/main/java/net/minecraftforge/eventbus/internal/Constants.java
@@ -34,9 +34,16 @@ final class Constants {
     static final int CHARACTERISTIC_INHERITABLE = 8;
 
     /**
+     * If true, performs additional runtime checks to aid debugging.
+     */
+    static final boolean STRICT_RUNTIME_CHECKS = Boolean.getBoolean("eventbus.api.strictRuntimeChecks");
+
+    /**
      * If true, performs exhaustive validation on bulk registration to aid debugging.
      */
-    static final boolean STRICT_REGISTRATION_CHECKS = Boolean.getBoolean("eventbus.api.strictRegistrationChecks");
+    static final boolean STRICT_REGISTRATION_CHECKS = STRICT_RUNTIME_CHECKS || Boolean.getBoolean("eventbus.api.strictRegistrationChecks");
+
+    static final boolean STRICT_BUS_CREATION_CHECKS = STRICT_RUNTIME_CHECKS || Boolean.getBoolean("eventbus.api.strictBusCreationChecks");
 
     /**
      * If true, allows the same listener to be registered multiple times. Intended for use in benchmarks only.

--- a/src/main/java/net/minecraftforge/eventbus/internal/EventListenerFactory.java
+++ b/src/main/java/net/minecraftforge/eventbus/internal/EventListenerFactory.java
@@ -38,7 +38,6 @@ final class EventListenerFactory {
 
     private static final Map<Method, MethodHandle> LMF_CACHE = new ConcurrentHashMap<>();
 
-    // Todo: [EB][Bulk registration] make the error messages more descriptive
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static Collection<EventListener> register(BusGroupImpl busGroup, MethodHandles.Lookup callerLookup,
                                                      Class<?> listenerClass, @Nullable Object listenerInstance) {
@@ -91,6 +90,8 @@ final class EventListenerFactory {
     /**
      * Same as {@link #register(BusGroupImpl, MethodHandles.Lookup, Class, Object)}, but with strict validation.
      * <p>Useful for debugging and dev environments, but slower than the normal method intended for production use.</p>
+     * <p>See also the "eventbus-validator" subproject, which uses an annotation processor to mirror these runtime
+     * checks at compile-time.</p>
      * @see Constants#STRICT_REGISTRATION_CHECKS
      */
     @SuppressWarnings({"unchecked"})

--- a/src/main/java/net/minecraftforge/eventbus/internal/EventListenerFactory.java
+++ b/src/main/java/net/minecraftforge/eventbus/internal/EventListenerFactory.java
@@ -131,7 +131,7 @@ final class EventListenerFactory {
             if (hasSubscribeEvent) {
                 var firstParamExtendsCancellable = Cancellable.class.isAssignableFrom(parameterTypes[0]);
                 var subscribeEventAnnotation = method.getAnnotation(SubscribeEvent.class);
-                var isMonitoringListener = subscribeEventAnnotation.priority() == Priority.MONITOR;
+                var isMonitoringPriority = subscribeEventAnnotation.priority() == Priority.MONITOR;
 
                 if (!firstParamExtendsEvent)
                     throw fail(method, "First parameter of a @SubscribeEvent method must be an event");
@@ -144,7 +144,7 @@ final class EventListenerFactory {
                 if (listenerInstance == null && !Modifier.isStatic(method.getModifiers()))
                     throw fail(method, "Listener instance is null and method is not static");
 
-                if (isMonitoringListener && (returnType == boolean.class || subscribeEventAnnotation.alwaysCancelling()))
+                if (isMonitoringPriority && (returnType == boolean.class || subscribeEventAnnotation.alwaysCancelling()))
                     throw fail(method, "Monitoring listeners cannot cancel events");
 
                 if (paramCount == 2) {
@@ -154,7 +154,7 @@ final class EventListenerFactory {
                     if (!boolean.class.isAssignableFrom(parameterTypes[1]))
                         throw fail(method, "Second parameter of a cancellation-aware monitoring listener must be a boolean");
 
-                    if (subscribeEventAnnotation.priority() != Priority.MONITOR)
+                    if (!isMonitoringPriority)
                         throw fail(method, "Cancellation-aware monitoring listeners must have a priority of MONITOR");
                 }
 


### PR DESCRIPTION
This PR enhances validation of API usages by library users and improves startup times.
- Introduced `eventbus.api.strictRuntimeChecks` and `eventbus.api.strictBusCreationChecks` system properties
- Added runtime check for incorrect `InheritableEvent`  usages
- Introduced a new annotation processor that shifts strict runtime checks to compile-time
- Moved some runtime checks to only apply in strict mode, relying instead on the compile-time validation and runtime opt-ins for faster startup
- Added documentation about the new behaviour in the [readme](https://github.com/PaintNinja/EventBus/blob/7.0-compile-time-validation/README.md#validation) and initial work on compile-time tests

## Behaviour changes
- Some runtime checks are now opt-in with the system properties mentioned above and no longer apply by default.
- Library users are expected to use the annotation processor for compile-time checks or opt-in to strict runtime checks as needed.

## New checks
### `InheritableEvent` usages
Throws exceptions at runtime and compile-time errors when an event type directly implements `InheritableEvent` but isn't inheritable. Thanks to @basdxz for reporting this edge-case to me.

Examples of incorrect usage:
```java
final class IncorrectUsage1 implements InheritableEvent { // should be `extends MutableEvent` instead
    static final EventBus<IncorrectUsage1> BUS = EventBus.create(IncorrectUsage1.class);
}

record IncorrectUsage2() implements InheritableEvent { // should be `implements RecordEvent` instead
    static final EventBus<IncorrectUsage2> BUS = EventBus.create(IncorrectUsage2.class);
}
```

Example of correct usage:
```java
sealed interface MouseClickEvent extends InheritableEvent {
    EventBus<MouseClickEvent> BUS = EventBus.create(MouseClickEvent.class);

    int x();
    int y();

    record Left(int x, int y) implements MouseClickEvent {
        static final EventBus<MouseClickEvent.Left> BUS = EventBus.create(MouseClickEvent.Left.class);
    }

    record Right(int x, int y) implements MouseClickEvent {
        static final EventBus<MouseClickEvent.Right> BUS = EventBus.create(MouseClickEvent.Right.class);
    }
}
```

### EventBus field modifiers
Emits a compile-time warning when `EventBus`/`CancellableEventBus` fields are not `final`. They should be final for performance reasons.

Example of incorrect usage:
```java
record IncorrectBusModifiersUsage() implements RecordEvent {
    static EventBus<IncorrectBusModifiersUsage> bus = EventBus.create(IncorrectBusModifiersUsage.class); // should be `final`
}
```

### EventBus field type
Emits a compile-time warning when a `Cancellable` event has a non-cancellable `EventBus` field type. This catches mistakes that can lead to event users being unable to register cancellable listeners.

Example of incorrect usage:
```java
record IncorrectBusTypeUsage() implements Cancellable, RecordEvent {
    static final EventBus<IncorrectBusTypeUsage> BUS = EventBus.create(IncorrectBusTypeUsage.class); // should be `CancellableEventBus` 
}
```

### Never cancelling listener with possibly cancelling return type
Emits a compile-time warning when a listener annotated with `@SubscribeEvent` always returns false, suggesting that the user changes to a `void` return type.

This helps library users write cleaner code and avoid a breaking change for that listener if the event is no longer cancellable in the future, as well as improves performance by allowing the `CancellableEventBus` to know ahead of time that the listener will never cancel the event and can potentially skip cancellation checks.

Example of incorrect usage:
```java
@SubscribeEvent
public static boolean incorrectListenerUsage(MyCancellableEvent event) { // should be `void` because it always returns false
    return false;
}
```