### PR TITLE
Fix validator by walking elements ourselves.

### DIFF
--- a/eventbus-test/build.gradle
+++ b/eventbus-test/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation libs.junit.api
     testImplementation libs.jspecify.annotations
     testImplementation libs.compile.testing
+    testImplementation libs.auto.value
     testImplementation libs.jetbrains.annotations
     testRuntimeOnly libs.bundles.junit.runtime
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,7 @@ dependencyResolutionManagement {
         library 'jmh-annotationProcessor', 'org.openjdk.jmh', 'jmh-generator-annprocess' versionRef 'jmh'
 
         library 'compile-testing', 'com.google.testing.compile', 'compile-testing' version '0.21.0'
+        library 'auto-value', 'com.google.auto.value', 'auto-value' version '1.11.0' // Need to bump this because compile-testing uses an old non-module compatible version
         library 'jetbrains-annotations', 'org.jetbrains', 'annotations' version '26.0.2'
     }
     //@formatter:on


### PR DESCRIPTION
This seems to fix using the validator on ForgeDev.
Basically skips your usage of com.sun.source.tree by walking the elements recursively ourselves.
The line that was triggering the javac weirdness was calling `trees.getElement`

Im a little confused because there are two tests that fail in eclipse, but succeed when running `gradlew eventbus-test:tests`. But I didn't touch anything related to that. Tho I didn't test before making my changes.

`EventBusCreationTests.testRecordEventValidation` and `EventBusCreationTests.testMonitorAwareEventValidation`