### PR TITLE
[6.2] Add Event#cancel() convenience method

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/api/Event.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/Event.java
@@ -73,8 +73,7 @@ public class Event {
      * @param cancel The new canceled value
      */
     public void setCanceled(boolean cancel) {
-        if (!isCancelable())
-        {
+        if (!isCancelable()) {
             throw new UnsupportedOperationException(
                 "Attempted to call Event#setCanceled() on a non-cancelable event of type: "
                 + this.getClass().getCanonicalName()
@@ -85,6 +84,13 @@ public class Event {
             throw new IllegalStateException("Attempted to call Event#setCanceled() after the MONITOR phase");
 
         isCanceled = cancel;
+    }
+
+    /**
+     * Equivalent to calling {@link #setCanceled(boolean)} with {@code true}.
+     */
+    public void cancel() {
+        setCanceled(true);
     }
 
     /**


### PR DESCRIPTION
To avoid a breaking change, this new method is not final, as doing so could break any events that added their own cancel method.